### PR TITLE
apps/api spring boot setup

### DIFF
--- a/backend/apps/api/build.gradle.kts
+++ b/backend/apps/api/build.gradle.kts
@@ -2,6 +2,43 @@ plugins {
   id("my.spring-app")
 }
 
+application {
+  mainClass = "io.github.cxwudi.nijigenvideosite.apps.api.ApiAppKt"
+}
+
+configurations {
+  compileOnly {
+    extendsFrom(configurations.annotationProcessor.get())
+  }
+}
+
 dependencies {
   implementation(project(":modules:common"))
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-cache")
+  implementation("org.springframework.boot:spring-boot-starter-jdbc")
+  implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
+  implementation("org.springframework.boot:spring-boot-starter-pulsar")
+  implementation("org.springframework.boot:spring-boot-starter-security")
+  implementation("org.springframework.boot:spring-boot-starter-security-oauth2-client")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
+  implementation("org.springframework.boot:spring-boot-starter-webmvc")
+  implementation("org.jetbrains.kotlin:kotlin-reflect")
+  implementation("tools.jackson.module:jackson-module-kotlin")
+  implementation(libs.dep.springdocOpenapiStarterWebmvcUi)
+
+  runtimeOnly("org.postgresql:postgresql")
+
+  annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+  testImplementation("org.springframework.boot:spring-boot-starter-actuator-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-cache-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-jdbc-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-opentelemetry-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-pulsar-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-security-oauth2-client-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/backend/apps/api/build.gradle.kts
+++ b/backend/apps/api/build.gradle.kts
@@ -6,12 +6,6 @@ application {
   mainClass = "io.github.cxwudi.nijigenvideosite.apps.api.ApiAppKt"
 }
 
-configurations {
-  compileOnly {
-    extendsFrom(configurations.annotationProcessor.get())
-  }
-}
-
 dependencies {
   implementation(project(":modules:common"))
   implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -27,6 +21,7 @@ dependencies {
   implementation("tools.jackson.module:jackson-module-kotlin")
   implementation(libs.dep.springdocOpenapiStarterWebmvcUi)
 
+  compileOnly("org.springframework.boot:spring-boot-configuration-processor")
   runtimeOnly("org.postgresql:postgresql")
 
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiApp.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiApp.kt
@@ -1,0 +1,17 @@
+package io.github.cxwudi.nijigenvideosite.apps.api
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * Main Spring Boot application for the HTTP API runtime.
+ */
+@SpringBootApplication
+class ApiApp
+
+/**
+ * Starts the API application.
+ */
+fun main(args: Array<String>) {
+  runApplication<ApiApp>(*args)
+}

--- a/backend/apps/api/src/main/resources/application.yaml
+++ b/backend/apps/api/src/main/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: apps-api

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt
@@ -2,11 +2,13 @@ package io.github.cxwudi.nijigenvideosite.apps.api
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 /**
  * Verifies that the API application context can be created.
  */
 @SpringBootTest
+@ActiveProfiles("test")
 class ApiAppTests {
 
   /**

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt
@@ -1,0 +1,18 @@
+package io.github.cxwudi.nijigenvideosite.apps.api
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Verifies that the API application context can be created.
+ */
+@SpringBootTest
+class ApiAppTests {
+
+  /**
+   * Loads the Spring application context.
+   */
+  @Test
+  fun contextLoads() {
+  }
+}

--- a/backend/apps/api/src/test/resources/application-test.yaml
+++ b/backend/apps/api/src/test/resources/application-test.yaml
@@ -1,0 +1,6 @@
+# Keep the bootstrap test free from local infrastructure requirements.
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
+      - org.springframework.boot.pulsar.autoconfigure.PulsarAutoConfiguration

--- a/backend/docs/folder-structure.md
+++ b/backend/docs/folder-structure.md
@@ -49,7 +49,7 @@ Holds backend runtime entrypoint modules.
 
 Currently implemented:
 
-- `api/`
+- `api/` request/response Spring Boot application for the backend HTTP API
 
 ### `docs/`
 
@@ -61,12 +61,9 @@ Holds shared Gradle assets for the backend workspace.
 
 Inside `gradle/`:
 
-- `libs.versions.toml`
-  shared version catalog
-- `plugins/`
-  internal Gradle plugin build
-- `wrapper/`
-  Gradle wrapper distribution files
+- `libs.versions.toml` shared version catalog
+- `plugins/` internal Gradle plugin build
+- `wrapper/` Gradle wrapper distribution files
 
 ### `modules/`
 
@@ -78,14 +75,10 @@ Currently implemented:
 
 ### Root-Level Gradle Files
 
-- `gradlew` and `gradlew.bat`
-  backend Gradle wrapper scripts
-- `settings.gradle.kts`
-  root Gradle settings file
-- `build.gradle.kts`
-  root Gradle build file
-- `gradle.properties`
-  backend-wide Gradle properties file
+- `gradlew` and `gradlew.bat` backend Gradle wrapper scripts
+- `settings.gradle.kts` root Gradle settings file
+- `build.gradle.kts` root Gradle build file
+- `gradle.properties` backend-wide Gradle properties file
 
 ## Notes
 

--- a/backend/docs/gradle-setup-explain.md
+++ b/backend/docs/gradle-setup-explain.md
@@ -21,6 +21,8 @@ The backend root is intentionally thin:
 - plugin coordinates
 
 The catalog is shared by the main backend build and the internal plugin build.
+When a BOM is cataloged, it becomes the source of truth for the versions it
+manages, so those libraries should not also get individual catalog entries.
 
 ## Internal Plugin Build
 
@@ -29,8 +31,9 @@ The backend uses an included build at `gradle/plugins/` for shared Gradle logic.
 That internal build contains:
 
 - `version-catalog/` generates Kotlin constants under `my.catalog` so
-  precompiled script plugins can consume catalog values from the TOML
-  file. This is a workaround for [gradle/gradle#15383](https://github.com/gradle/gradle/issues/15383)
+  precompiled script plugins can consume catalog values from the TOML file. This
+  is a workaround for
+  [gradle/gradle#15383](https://github.com/gradle/gradle/issues/15383)
 - `backend/` contains the backend convention plugins used by backend modules
 - `settings/` contains the backend settings plugin used by the root settings
   file
@@ -43,12 +46,18 @@ The current backend convention plugins are:
   test setup
 - `my.lib` reusable library-module conventions layered on top of `my.jvm-common`
 - `my.spring-app` application-module conventions layered on top of
-  `my.jvm-common`, plus Spring Boot and GraalVM native support
+  `my.jvm-common`, plus the Kotlin Spring plugin, Spring Boot, GraalVM native
+  support, and the Spring BOM
 
 The backend settings plugin is:
 
 - `my.root-settings-plugins` wraps the Develocity and Foojay settings plugins
   for backend settings
+
+In the current backend workspace:
+
+- modules under `apps/` use `my.spring-app`
+- reusable modules under `modules/` use `my.lib`
 
 ## Build Environment
 

--- a/backend/docs/tech-stack.md
+++ b/backend/docs/tech-stack.md
@@ -7,6 +7,9 @@ This document lists the current committed backend stack.
 - Java `25` (GraalVM)
 - [Kotlin](https://kotlinlang.org/docs/home.html)
 - [Spring Boot](https://docs.spring.io/spring-boot/reference/)
+  - For AI Agents: be aware that we are on Spring Boot `4.x`. Many things you
+    used to know are not applicable anymore. Make sure to always check the
+    latest documentation.
 
 ## Build and Dependency Management
 

--- a/backend/docs/tech-stack.md
+++ b/backend/docs/tech-stack.md
@@ -6,38 +6,38 @@ This document lists the current committed backend stack.
 
 - Java `25` (GraalVM)
 - [Kotlin](https://kotlinlang.org/docs/home.html)
-- [Spring Boot](https://docs.spring.io/spring-boot/index.html)
+- [Spring Boot](https://docs.spring.io/spring-boot/reference/)
 
 ## Build and Dependency Management
 
 - [Gradle](https://docs.gradle.org/current/userguide/userguide.html)
 - [Develocity](https://docs.gradle.com/develocity/current/)
-- [Spring Configuration Processor](https://docs.spring.io/spring-boot/4.0.5/specification/configuration-metadata/annotation-processor.html)
+- [Spring Configuration Processor](https://docs.spring.io/spring-boot/specification/configuration-metadata/annotation-processor.html)
 
 ## Web and API
 
-- [Spring Web MVC](https://docs.spring.io/spring-boot/4.0.5/reference/web/servlet.html)
+- [Spring Web MVC](https://docs.spring.io/spring-boot/reference/web/servlet.html)
 - [SpringDoc OpenAPI](https://springdoc.org/)
 
 ## Security
 
-- [Spring Security](https://docs.spring.io/spring-boot/4.0.5/reference/web/spring-security.html)
-- [OAuth2 Client](https://docs.spring.io/spring-boot/4.0.5/reference/web/spring-security.html#web.security.oauth2.client)
+- [Spring Security](https://docs.spring.io/spring-boot/reference/web/spring-security.html)
+- [OAuth2 Client](https://docs.spring.io/spring-boot/reference/web/spring-security.html#web.security.oauth2.client)
 
 ## Data and Messaging
 
-- [Spring JDBC](https://docs.spring.io/spring-boot/4.0.5/reference/data/sql.html)
+- [Spring JDBC](https://docs.spring.io/spring-boot/reference/data/sql.html)
 - [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/)
-- [Spring Cache Abstraction](https://docs.spring.io/spring-boot/4.0.5/reference/io/caching.html)
-- [Spring for Apache Pulsar](https://docs.spring.io/spring-boot/4.0.5/reference/messaging/pulsar.html)
+- [Spring Cache Abstraction](https://docs.spring.io/spring-boot/reference/io/caching.html)
+- [Spring for Apache Pulsar](https://docs.spring.io/spring-boot/reference/messaging/pulsar.html)
 
 ## Observability and Operations
 
-- [Spring Boot Actuator](https://docs.spring.io/spring-boot/4.0.5/reference/actuator/index.html)
-- [OpenTelemetry](https://docs.spring.io/spring-boot/4.0.5/reference/actuator/observability.html#actuator.observability.opentelemetry)
+- [Spring Boot Actuator](https://docs.spring.io/spring-boot/reference/actuator/index.html)
+- [OpenTelemetry](https://docs.spring.io/spring-boot/reference/actuator/observability.html#actuator.observability.opentelemetry)
 
 ## Validation and Testing
 
-- [Validation](https://docs.spring.io/spring-boot/4.0.5/reference/io/validation.html)
+- [Validation](https://docs.spring.io/spring-boot/reference/io/validation.html)
 - [JUnit](https://junit.org/junit5/docs/current/user-guide/)
 - [MockK](https://mockk.io/)

--- a/backend/docs/tech-stack.md
+++ b/backend/docs/tech-stack.md
@@ -12,8 +12,32 @@ This document lists the current committed backend stack.
 
 - [Gradle](https://docs.gradle.org/current/userguide/userguide.html)
 - [Develocity](https://docs.gradle.com/develocity/current/)
+- [Spring Configuration Processor](https://docs.spring.io/spring-boot/4.0.5/specification/configuration-metadata/annotation-processor.html)
 
-## Testing
+## Web and API
 
+- [Spring Web MVC](https://docs.spring.io/spring-boot/4.0.5/reference/web/servlet.html)
+- [SpringDoc OpenAPI](https://springdoc.org/)
+
+## Security
+
+- [Spring Security](https://docs.spring.io/spring-boot/4.0.5/reference/web/spring-security.html)
+- [OAuth2 Client](https://docs.spring.io/spring-boot/4.0.5/reference/web/spring-security.html#web.security.oauth2.client)
+
+## Data and Messaging
+
+- [Spring JDBC](https://docs.spring.io/spring-boot/4.0.5/reference/data/sql.html)
+- [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/)
+- [Spring Cache Abstraction](https://docs.spring.io/spring-boot/4.0.5/reference/io/caching.html)
+- [Spring for Apache Pulsar](https://docs.spring.io/spring-boot/4.0.5/reference/messaging/pulsar.html)
+
+## Observability and Operations
+
+- [Spring Boot Actuator](https://docs.spring.io/spring-boot/4.0.5/reference/actuator/index.html)
+- [OpenTelemetry](https://docs.spring.io/spring-boot/4.0.5/reference/actuator/observability.html#actuator.observability.opentelemetry)
+
+## Validation and Testing
+
+- [Validation](https://docs.spring.io/spring-boot/4.0.5/reference/io/validation.html)
 - [JUnit](https://junit.org/junit5/docs/current/user-guide/)
 - [MockK](https://mockk.io/)

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ foojay-resolver = "1.0.0"
 bom-springBoot = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 bom-junit = "org.junit:junit-bom:6.0.3"
 dep-mockk = "io.mockk:mockk:1.14.9"
+dep-springdocOpenapiStarterWebmvcUi = "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2"
 
 pluginDep-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 pluginDep-kotlinSpring = { module = "org.jetbrains.kotlin.plugin.spring:org.jetbrains.kotlin.plugin.spring.gradle.plugin", version.ref = "kotlin" }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -8,12 +8,15 @@ develocity = "4.4.0"
 foojay-resolver = "1.0.0"
 
 [libraries]
+# When a BOM is listed here, it becomes the version source of truth for the
+# libraries it manages. Do not add separate catalog entries for BOM-managed
+# libraries unless they intentionally need to live outside that BOM.
 bom-springBoot = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 bom-junit = "org.junit:junit-bom:6.0.3"
-dep-junitJupiter = { module = "org.junit.jupiter:junit-jupiter" }
 dep-mockk = "io.mockk:mockk:1.14.9"
 
 pluginDep-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+pluginDep-kotlinSpring = { module = "org.jetbrains.kotlin.plugin.spring:org.jetbrains.kotlin.plugin.spring.gradle.plugin", version.ref = "kotlin" }
 pluginDep-springBoot = { module = "org.springframework.boot:spring-boot-gradle-plugin", version.ref = "spring-boot" }
 pluginDep-graalvmNative = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalvm-native" }
 

--- a/backend/gradle/plugins/backend/build.gradle.kts
+++ b/backend/gradle/plugins/backend/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   implementation(project(":version-catalog"))
   implementation(libs.pluginDep.kotlin)
+  implementation(libs.pluginDep.kotlinSpring)
   implementation(libs.pluginDep.springBoot)
   implementation(libs.pluginDep.graalvmNative)
 }

--- a/backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts
+++ b/backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts
@@ -34,6 +34,6 @@ tasks.withType<Test>().configureEach {
 
 dependencies {
   testImplementation(platform(Libs.JunitBom))
-  testImplementation(Libs.JunitJupiter)
+  testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation(Libs.Mockk)
 }

--- a/backend/gradle/plugins/backend/src/main/kotlin/my.spring-app.gradle.kts
+++ b/backend/gradle/plugins/backend/src/main/kotlin/my.spring-app.gradle.kts
@@ -23,5 +23,6 @@ tasks.named<CreateStartScripts>("startScripts") {
 
 dependencies {
   implementation(platform(Libs.SpringBootBom))
+  compileOnly(platform(Libs.SpringBootBom))
   annotationProcessor(platform(Libs.SpringBootBom))
 }

--- a/backend/gradle/plugins/backend/src/main/kotlin/my.spring-app.gradle.kts
+++ b/backend/gradle/plugins/backend/src/main/kotlin/my.spring-app.gradle.kts
@@ -4,6 +4,7 @@ import org.gradle.jvm.application.tasks.CreateStartScripts
 plugins {
   id("my.jvm-common")
   application
+  kotlin("plugin.spring")
   id("org.springframework.boot")
   id("org.graalvm.buildtools.native")
 }

--- a/backend/gradle/plugins/version-catalog/build.gradle.kts
+++ b/backend/gradle/plugins/version-catalog/build.gradle.kts
@@ -18,7 +18,6 @@ buildConfig {
   forClass(packageName = "my.catalog", className = "Libs") {
     buildConfigStringField("SpringBootBom", libs.bom.springBoot)
     buildConfigStringField("JunitBom", libs.bom.junit)
-    buildConfigStringField("JunitJupiter", libs.dep.junitJupiter)
     buildConfigStringField("Mockk", libs.dep.mockk)
   }
 }


### PR DESCRIPTION
## Summary
- align backend Spring app conventions with the Spring Boot API bootstrap and BOM rules
- bootstrap backend/apps/api as the first real Spring Boot application module with deterministic tests
- refresh backend docs and latest-link Spring references to match the committed backend state

## Testing
- cd backend && GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :apps:api:test

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched HTTP API backend with OAuth2 authentication, Spring Security, data access (Postgres/JDBC), validation, caching, messaging, and observability
  * Added interactive API documentation (OpenAPI UI) and Kotlin/Jackson support for JSON handling

* **Tests**
  * Added application bootstrap validation tests with test-specific configuration to skip external integrations

* **Documentation**
  * Updated tech stack and folder/Gradle guidance to reflect the new API and build setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->