### PR TITLE
Add sample user table CRUD API

### DIFF
--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
@@ -1,0 +1,88 @@
+package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
+
+import jakarta.validation.Valid
+import java.net.URI
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * REST controller for the temporary sample-user CRUD API.
+ */
+@RestController
+@RequestMapping("/sample-users")
+class SampleUserController(private val repository: SampleUserRepository) {
+
+  /**
+   * Creates a sample user and returns its canonical API location.
+   */
+  @PostMapping
+  fun create(@Valid @RequestBody request: CreateSampleUserRequest): ResponseEntity<SampleUser> {
+    val sampleUser = repository.create(request)
+
+    return ResponseEntity
+      .created(URI.create("/sample-users/${sampleUser.id}"))
+      .body(sampleUser)
+  }
+
+  /**
+   * Lists all sample users.
+   */
+  @GetMapping
+  fun list(): List<SampleUser> = repository.findAll()
+
+  /**
+   * Returns one sample user by id.
+   */
+  @GetMapping("/{id}")
+  fun findById(@PathVariable id: Long): SampleUser =
+    repository.findById(id) ?: throw notFound(id)
+
+  /**
+   * Replaces editable fields for one sample user.
+   */
+  @PutMapping("/{id}")
+  fun update(
+    @PathVariable id: Long,
+    @Valid @RequestBody request: UpdateSampleUserRequest,
+  ): SampleUser =
+    repository.update(id, request) ?: throw notFound(id)
+
+  /**
+   * Deletes one sample user.
+   */
+  @DeleteMapping("/{id}")
+  fun delete(@PathVariable id: Long): ResponseEntity<Void> {
+    if (!repository.deleteById(id)) {
+      throw notFound(id)
+    }
+
+    return ResponseEntity.noContent().build()
+  }
+
+  /**
+   * Converts duplicate usernames into a client-correctable response.
+   */
+  @ExceptionHandler(DuplicateKeyException::class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  fun handleDuplicateUsername(): ProblemDetail =
+    ProblemDetail.forStatusAndDetail(
+      HttpStatus.BAD_REQUEST,
+      "A sample user with that username already exists.",
+    )
+
+  private fun notFound(id: Long): ResponseStatusException =
+    ResponseStatusException(HttpStatus.NOT_FOUND, "Sample user $id was not found.")
+}

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
@@ -1,7 +1,6 @@
 package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
 
 import jakarta.validation.Valid
-import java.net.URI
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import org.springframework.web.server.ResponseStatusException
 
 /**
@@ -31,9 +31,14 @@ class SampleUserController(private val repository: SampleUserRepository) {
   @PostMapping
   fun create(@Valid @RequestBody request: CreateSampleUserRequest): ResponseEntity<SampleUser> {
     val sampleUser = repository.create(request)
+    val location = ServletUriComponentsBuilder
+      .fromCurrentRequest()
+      .path("/{id}")
+      .buildAndExpand(sampleUser.id)
+      .toUri()
 
     return ResponseEntity
-      .created(URI.create("/sample-users/${sampleUser.id}"))
+      .created(location)
       .body(sampleUser)
   }
 
@@ -76,10 +81,10 @@ class SampleUserController(private val repository: SampleUserRepository) {
    * Converts duplicate usernames into a client-correctable response.
    */
   @ExceptionHandler(DuplicateKeyException::class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseStatus(HttpStatus.CONFLICT)
   fun handleDuplicateUsernameOrEmail(): ProblemDetail =
     ProblemDetail.forStatusAndDetail(
-      HttpStatus.BAD_REQUEST,
+      HttpStatus.CONFLICT,
       "A sample user with that username or email already exists.",
     )
 

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt
@@ -77,10 +77,10 @@ class SampleUserController(private val repository: SampleUserRepository) {
    */
   @ExceptionHandler(DuplicateKeyException::class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  fun handleDuplicateUsername(): ProblemDetail =
+  fun handleDuplicateUsernameOrEmail(): ProblemDetail =
     ProblemDetail.forStatusAndDetail(
       HttpStatus.BAD_REQUEST,
-      "A sample user with that username already exists.",
+      "A sample user with that username or email already exists.",
     )
 
   private fun notFound(id: Long): ResponseStatusException =

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserModels.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserModels.kt
@@ -1,5 +1,6 @@
 package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import java.time.OffsetDateTime
@@ -10,7 +11,9 @@ import java.time.OffsetDateTime
 data class SampleUser(
   val id: Long,
   val username: String,
+  val email: String,
   val displayName: String,
+  val bio: String?,
   val createdAt: OffsetDateTime,
 )
 
@@ -23,8 +26,16 @@ data class CreateSampleUserRequest(
   val username: String,
 
   @field:NotBlank
+  @field:Email
+  @field:Size(max = 255)
+  val email: String,
+
+  @field:NotBlank
   @field:Size(max = 120)
   val displayName: String,
+
+  @field:Size(max = 500)
+  val bio: String? = null,
 )
 
 /**
@@ -36,6 +47,14 @@ data class UpdateSampleUserRequest(
   val username: String,
 
   @field:NotBlank
+  @field:Email
+  @field:Size(max = 255)
+  val email: String,
+
+  @field:NotBlank
   @field:Size(max = 120)
   val displayName: String,
+
+  @field:Size(max = 500)
+  val bio: String? = null,
 )

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserModels.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserModels.kt
@@ -1,0 +1,41 @@
+package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.time.OffsetDateTime
+
+/**
+ * Sample user row exposed by the temporary CRUD API.
+ */
+data class SampleUser(
+  val id: Long,
+  val username: String,
+  val displayName: String,
+  val createdAt: OffsetDateTime,
+)
+
+/**
+ * Request body used to create a sample user.
+ */
+data class CreateSampleUserRequest(
+  @field:NotBlank
+  @field:Size(max = 64)
+  val username: String,
+
+  @field:NotBlank
+  @field:Size(max = 120)
+  val displayName: String,
+)
+
+/**
+ * Request body used to replace editable sample user fields.
+ */
+data class UpdateSampleUserRequest(
+  @field:NotBlank
+  @field:Size(max = 64)
+  val username: String,
+
+  @field:NotBlank
+  @field:Size(max = 120)
+  val displayName: String,
+)

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserRepository.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserRepository.kt
@@ -18,13 +18,15 @@ class SampleUserRepository(private val jdbcClient: JdbcClient) {
     jdbcClient
       .sql(
         """
-        INSERT INTO sample_users (username, display_name)
-        VALUES (:username, :displayName)
-        RETURNING id, username, display_name, created_at
+        INSERT INTO sample_users (username, email, display_name, bio)
+        VALUES (:username, :email, :displayName, :bio)
+        RETURNING id, username, email, display_name, bio, created_at
         """.trimIndent(),
       )
       .param("username", request.username)
+      .param("email", request.email)
       .param("displayName", request.displayName)
+      .param("bio", request.bio)
       .query(sampleUserRowMapper)
       .single()
 
@@ -35,7 +37,7 @@ class SampleUserRepository(private val jdbcClient: JdbcClient) {
     jdbcClient
       .sql(
         """
-        SELECT id, username, display_name, created_at
+        SELECT id, username, email, display_name, bio, created_at
         FROM sample_users
         WHERE id = :id
         """.trimIndent(),
@@ -52,7 +54,7 @@ class SampleUserRepository(private val jdbcClient: JdbcClient) {
     jdbcClient
       .sql(
         """
-        SELECT id, username, display_name, created_at
+        SELECT id, username, email, display_name, bio, created_at
         FROM sample_users
         ORDER BY id
         """.trimIndent(),
@@ -69,14 +71,18 @@ class SampleUserRepository(private val jdbcClient: JdbcClient) {
         """
         UPDATE sample_users
         SET username = :username,
-            display_name = :displayName
+            email = :email,
+            display_name = :displayName,
+            bio = :bio
         WHERE id = :id
-        RETURNING id, username, display_name, created_at
+        RETURNING id, username, email, display_name, bio, created_at
         """.trimIndent(),
       )
       .param("id", id)
       .param("username", request.username)
+      .param("email", request.email)
       .param("displayName", request.displayName)
+      .param("bio", request.bio)
       .query(sampleUserRowMapper)
       .optional()
       .orElse(null)
@@ -101,7 +107,9 @@ class SampleUserRepository(private val jdbcClient: JdbcClient) {
         SampleUser(
           id = resultSet.getLong("id"),
           username = resultSet.getString("username"),
+          email = resultSet.getString("email"),
           displayName = resultSet.getString("display_name"),
+          bio = resultSet.getString("bio"),
           createdAt = resultSet.getObject("created_at", OffsetDateTime::class.java),
         )
       }

--- a/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserRepository.kt
+++ b/backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserRepository.kt
@@ -1,0 +1,109 @@
+package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
+
+import java.time.OffsetDateTime
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.stereotype.Repository
+
+/**
+ * JDBC repository for the disposable `sample_users` table.
+ */
+@Repository
+class SampleUserRepository(private val jdbcClient: JdbcClient) {
+
+  /**
+   * Inserts a sample user and returns the persisted row.
+   */
+  fun create(request: CreateSampleUserRequest): SampleUser =
+    jdbcClient
+      .sql(
+        """
+        INSERT INTO sample_users (username, display_name)
+        VALUES (:username, :displayName)
+        RETURNING id, username, display_name, created_at
+        """.trimIndent(),
+      )
+      .param("username", request.username)
+      .param("displayName", request.displayName)
+      .query(sampleUserRowMapper)
+      .single()
+
+  /**
+   * Finds a sample user by primary key.
+   */
+  fun findById(id: Long): SampleUser? =
+    jdbcClient
+      .sql(
+        """
+        SELECT id, username, display_name, created_at
+        FROM sample_users
+        WHERE id = :id
+        """.trimIndent(),
+      )
+      .param("id", id)
+      .query(sampleUserRowMapper)
+      .optional()
+      .orElse(null)
+
+  /**
+   * Lists all sample users in stable insertion order.
+   */
+  fun findAll(): List<SampleUser> =
+    jdbcClient
+      .sql(
+        """
+        SELECT id, username, display_name, created_at
+        FROM sample_users
+        ORDER BY id
+        """.trimIndent(),
+      )
+      .query(sampleUserRowMapper)
+      .list()
+
+  /**
+   * Replaces editable fields for an existing sample user.
+   */
+  fun update(id: Long, request: UpdateSampleUserRequest): SampleUser? =
+    jdbcClient
+      .sql(
+        """
+        UPDATE sample_users
+        SET username = :username,
+            display_name = :displayName
+        WHERE id = :id
+        RETURNING id, username, display_name, created_at
+        """.trimIndent(),
+      )
+      .param("id", id)
+      .param("username", request.username)
+      .param("displayName", request.displayName)
+      .query(sampleUserRowMapper)
+      .optional()
+      .orElse(null)
+
+  /**
+   * Deletes a sample user by primary key.
+   */
+  fun deleteById(id: Long): Boolean =
+    jdbcClient
+      .sql(
+        """
+        DELETE FROM sample_users
+        WHERE id = :id
+        """.trimIndent(),
+      )
+      .param("id", id)
+      .update() == 1
+
+  private companion object {
+    private val sampleUserRowMapper =
+      RowMapper { resultSet, _ ->
+        SampleUser(
+          id = resultSet.getLong("id"),
+          username = resultSet.getString("username"),
+          displayName = resultSet.getString("display_name"),
+          createdAt = resultSet.getObject("created_at", OffsetDateTime::class.java),
+        )
+      }
+  }
+}

--- a/backend/apps/api/src/main/resources/application.yaml
+++ b/backend/apps/api/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: apps-api
+  threads:
+    virtual:
+      enabled: true
 
 # use the application-local.yml profile when connecting to external services via port forwarding in compose files
 # for CI and dev inside docker compose, the compose files have already configured connection details via env var

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
@@ -1,0 +1,194 @@
+package io.github.cxwudi.nijigenvideosite.apps.api.sampleusers
+
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.jdbc.core.simple.JdbcClient
+import org.springframework.test.annotation.Rollback
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.transaction.AfterTransaction
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
+
+/**
+ * Verifies the sample-user API against the real Spring MVC and JDBC stack.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+@Rollback
+class SampleUserControllerIntegrationTests @Autowired constructor(
+  private val mockMvc: MockMvc,
+  private val objectMapper: ObjectMapper,
+  private val jdbcClient: JdbcClient,
+) {
+  private val usernamePrefix = "sample-user-test-${UUID.randomUUID()}-"
+
+  /**
+   * Verifies that a created sample user can be fetched directly and listed.
+   */
+  @Test
+  fun createReadAndListSampleUser() {
+    val username = nextUsername("create-read-list")
+    val created = postSampleUser(
+      CreateSampleUserRequest(
+        username = username,
+        displayName = "Create Read List",
+      ),
+    )
+
+    mockMvc
+      .perform(get("/sample-users/{id}", created.id))
+      .andExpect(status().isOk)
+      .andExpect(jsonPath("\$.id").value(created.id))
+      .andExpect(jsonPath("\$.username").value(username))
+      .andExpect(jsonPath("\$.displayName").value("Create Read List"))
+
+    val listResult = mockMvc
+      .perform(get("/sample-users"))
+      .andExpect(status().isOk)
+      .andReturn()
+
+    val listedUsers = objectMapper.readValue<List<SampleUser>>(
+      listResult.response.contentAsString,
+    )
+
+    assertTrue(
+      listedUsers.any { sampleUser ->
+        sampleUser.id == created.id && sampleUser.username == username
+      },
+      "Expected the created sample user to be present in the list response.",
+    )
+  }
+
+  /**
+   * Verifies that editable sample-user fields can be updated before deletion.
+   */
+  @Test
+  fun updateAndDeleteSampleUser() {
+    val created = postSampleUser(
+      CreateSampleUserRequest(
+        username = nextUsername("update-delete"),
+        displayName = "Before Update",
+      ),
+    )
+
+    val updatedUsername = nextUsername("updated")
+    val updateResult = mockMvc
+      .perform(
+        put("/sample-users/{id}", created.id)
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            objectMapper.writeValueAsString(
+              UpdateSampleUserRequest(
+                username = updatedUsername,
+                displayName = "After Update",
+              ),
+            ),
+          ),
+      )
+      .andExpect(status().isOk)
+      .andExpect(jsonPath("\$.id").value(created.id))
+      .andExpect(jsonPath("\$.username").value(updatedUsername))
+      .andExpect(jsonPath("\$.displayName").value("After Update"))
+      .andReturn()
+
+    val updated = objectMapper.readValue<SampleUser>(
+      updateResult.response.contentAsString,
+    )
+
+    assertEquals(created.id, updated.id)
+    assertEquals(updatedUsername, updated.username)
+    assertEquals("After Update", updated.displayName)
+
+    mockMvc
+      .perform(delete("/sample-users/{id}", created.id))
+      .andExpect(status().isNoContent)
+
+    mockMvc
+      .perform(get("/sample-users/{id}", created.id))
+      .andExpect(status().isNotFound)
+  }
+
+  /**
+   * Verifies request validation turns invalid input into a client error.
+   */
+  @Test
+  fun rejectBlankUsername() {
+    mockMvc
+      .perform(
+        post("/sample-users")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(
+            objectMapper.writeValueAsString(
+              CreateSampleUserRequest(
+                username = " ",
+                displayName = "Invalid User",
+              ),
+            ),
+          ),
+      )
+      .andExpect(status().isBadRequest)
+  }
+
+  /**
+   * Verifies transaction rollback removes rows created by each test.
+   */
+  @AfterTransaction
+  fun sampleUsersCreatedByTestsAreRolledBack() {
+    val remainingTestRows = jdbcClient
+      .sql(
+        """
+        SELECT COUNT(*)
+        FROM sample_users
+        WHERE username LIKE :usernamePrefix
+        """.trimIndent(),
+      )
+      .param("usernamePrefix", "$usernamePrefix%")
+      .query(Long::class.java)
+      .single()
+
+    assertEquals(
+      0L,
+      remainingTestRows,
+      "Expected test-created sample users to be removed by transaction rollback.",
+    )
+  }
+
+  /**
+   * Creates a sample user through the public API.
+   */
+  private fun postSampleUser(request: CreateSampleUserRequest): SampleUser {
+    val result = mockMvc
+      .perform(
+        post("/sample-users")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)),
+      )
+      .andExpect(status().isCreated)
+      .andExpect(jsonPath("\$.username").value(request.username))
+      .andExpect(jsonPath("\$.displayName").value(request.displayName))
+      .andReturn()
+
+    return objectMapper.readValue(result.response.contentAsString)
+  }
+
+  /**
+   * Builds a unique username for this test class execution.
+   */
+  private fun nextUsername(suffix: String): String = "$usernamePrefix$suffix"
+}

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
@@ -160,6 +160,30 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
   }
 
   /**
+   * Verifies duplicate unique sample-user fields are reported as conflicts.
+   */
+  @Test
+  fun rejectDuplicateUsernameOrEmail() {
+    val username = nextUsername("duplicate")
+    val email = nextEmail("duplicate")
+    val request = CreateSampleUserRequest(
+      username = username,
+      email = email,
+      displayName = "Duplicate User",
+    )
+
+    postSampleUser(request)
+
+    mockMvc
+      .perform(
+        post("/sample-users")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(request)),
+      )
+      .andExpect(status().isConflict)
+  }
+
+  /**
    * Verifies transaction rollback removes rows created by each test.
    */
   @AfterTransaction
@@ -199,7 +223,10 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
       .andExpect(jsonPath("\$.displayName").value(request.displayName))
       .andReturn()
 
-    return objectMapper.readValue(result.response.contentAsString)
+    val sampleUser = objectMapper.readValue<SampleUser>(result.response.contentAsString)
+    assertEquals("http://localhost/sample-users/${sampleUser.id}", result.response.getHeader("Location"))
+
+    return sampleUser
   }
 
   /**

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
@@ -36,7 +36,7 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
   private val objectMapper: ObjectMapper,
   private val jdbcClient: JdbcClient,
 ) {
-  private val usernamePrefix = "sample-user-test-${UUID.randomUUID()}-"
+  private val usernamePrefix = "sut-${UUID.randomUUID().toString().take(8)}-"
 
   /**
    * Verifies that a created sample user can be fetched directly and listed.
@@ -210,5 +210,5 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
   /**
    * Builds a unique email for this test class execution.
    */
-  private fun nextEmail(suffix: String): String = "$usernamePrefix$suffix@example.test"
+  private fun nextEmail(suffix: String): String = "$usernamePrefix$suffix@example.com"
 }

--- a/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
+++ b/backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt
@@ -47,7 +47,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
     val created = postSampleUser(
       CreateSampleUserRequest(
         username = username,
+        email = nextEmail("create-read-list"),
         displayName = "Create Read List",
+        bio = "Created during a rollback-safe integration test.",
       ),
     )
 
@@ -56,7 +58,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
       .andExpect(status().isOk)
       .andExpect(jsonPath("\$.id").value(created.id))
       .andExpect(jsonPath("\$.username").value(username))
+      .andExpect(jsonPath("\$.email").value(nextEmail("create-read-list")))
       .andExpect(jsonPath("\$.displayName").value("Create Read List"))
+      .andExpect(jsonPath("\$.bio").value("Created during a rollback-safe integration test."))
 
     val listResult = mockMvc
       .perform(get("/sample-users"))
@@ -83,11 +87,14 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
     val created = postSampleUser(
       CreateSampleUserRequest(
         username = nextUsername("update-delete"),
+        email = nextEmail("update-delete"),
         displayName = "Before Update",
+        bio = null,
       ),
     )
 
     val updatedUsername = nextUsername("updated")
+    val updatedEmail = nextEmail("updated")
     val updateResult = mockMvc
       .perform(
         put("/sample-users/{id}", created.id)
@@ -96,7 +103,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
             objectMapper.writeValueAsString(
               UpdateSampleUserRequest(
                 username = updatedUsername,
+                email = updatedEmail,
                 displayName = "After Update",
+                bio = "Updated bio",
               ),
             ),
           ),
@@ -104,7 +113,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
       .andExpect(status().isOk)
       .andExpect(jsonPath("\$.id").value(created.id))
       .andExpect(jsonPath("\$.username").value(updatedUsername))
+      .andExpect(jsonPath("\$.email").value(updatedEmail))
       .andExpect(jsonPath("\$.displayName").value("After Update"))
+      .andExpect(jsonPath("\$.bio").value("Updated bio"))
       .andReturn()
 
     val updated = objectMapper.readValue<SampleUser>(
@@ -113,7 +124,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
 
     assertEquals(created.id, updated.id)
     assertEquals(updatedUsername, updated.username)
+    assertEquals(updatedEmail, updated.email)
     assertEquals("After Update", updated.displayName)
+    assertEquals("Updated bio", updated.bio)
 
     mockMvc
       .perform(delete("/sample-users/{id}", created.id))
@@ -137,6 +150,7 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
             objectMapper.writeValueAsString(
               CreateSampleUserRequest(
                 username = " ",
+                email = nextEmail("invalid"),
                 displayName = "Invalid User",
               ),
             ),
@@ -181,6 +195,7 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
       )
       .andExpect(status().isCreated)
       .andExpect(jsonPath("\$.username").value(request.username))
+      .andExpect(jsonPath("\$.email").value(request.email))
       .andExpect(jsonPath("\$.displayName").value(request.displayName))
       .andReturn()
 
@@ -191,4 +206,9 @@ class SampleUserControllerIntegrationTests @Autowired constructor(
    * Builds a unique username for this test class execution.
    */
   private fun nextUsername(suffix: String): String = "$usernamePrefix$suffix"
+
+  /**
+   * Builds a unique email for this test class execution.
+   */
+  private fun nextEmail(suffix: String): String = "$usernamePrefix$suffix@example.test"
 }

--- a/backend/docker/mise.toml
+++ b/backend/docker/mise.toml
@@ -55,5 +55,6 @@ export HOST_GRADLE_USER_HOME="${HOST_GRADLE_USER_HOME:-$HOME/.gradle}"
 export HOST_UID="${HOST_UID:-$(id -u)}"
 export HOST_GID="${HOST_GID:-$(id -g)}"
 mkdir -p "$HOST_GRADLE_USER_HOME"
+trap 'printf "\nBackend dependency services may still be running. Run: mise //backend/docker:down when you are done.\n"' EXIT
 {{ vars.compose }} run "$@"
 '''

--- a/design-log/plans/plan-issue-9-sample-user-table-20260512.md
+++ b/design-log/plans/plan-issue-9-sample-user-table-20260512.md
@@ -1,0 +1,311 @@
+# Sample User Table Implementation Plan
+
+> **For agentic workers:** Use the harness's preferred task-tracking and
+> delegation tools when available. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Add a small CRUD API for a backend `sample_users` table and test
+that API data changes are rolled back after each test, while enabling Spring
+Boot virtual threads for the API runtime.
+
+**Source of Truth:** GitHub issue `#9` plus the user's explicit requests to add
+sample user-table backend behavior, use `JdbcClient`, name code around
+`SampleUser`, use a `sample_users` table, enable Spring Boot virtual threads,
+and test that modified data is reverted.
+
+**Scope:** Includes repository/controller/model code for sample user CRUD,
+integration tests using the real Spring/JDBC stack, and a CI wiring check.
+Excludes authentication integration, Keycloak user syncing, production user
+profile design, frontend changes, and broad backend architecture refactors.
+
+**Approach:** Use the current `spring-boot-starter-jdbc` stack, specifically Spring
+`JdbcClient`, and a small disposable `sample_users` table instead of introducing
+JPA. Because the project is still at a very early stage and this sample table is
+expected to be removed later, update the existing V1 baseline migration directly
+instead of adding a new migration. Add small model, repository, and controller
+classes under the API module's package root, then verify through
+Spring MVC integration tests that run inside the existing Compose-backed backend
+test flow. Keep the test data rollback explicit with transactional tests plus
+post-transaction cleanup assertions. Enable Spring Boot virtual threads with
+`spring.threads.virtual.enabled: true` in the API application configuration,
+which is the documented Spring Boot 4 property for Java 21+ applications.
+
+**Verification:** Run the focused API test task through the backend Compose
+wrapper used by CI: `mise //backend/docker:run --rm api :apps:api:test`. Also
+confirm `git status` only contains intended source/test/CI changes. Commit after
+each completed task so the implementation lands as small reviewable steps.
+
+---
+
+## Branch Workflow
+
+Create a dedicated task branch before touching implementation files. Suggested
+branch name: `issue-9-sample-user-table`. If that branch name already exists,
+choose the nearest repo-consistent variant and record it in the execution
+summary.
+
+## Commit Cadence
+
+Commit after every completed task in this plan. Each commit should contain only
+that task's focused changes plus any small correction strictly required to keep
+the repository coherent at that checkpoint. Use the repository commit workflow
+and keep commit messages scoped to the task outcome.
+
+### Task 0: Create The Task Branch
+
+#### 0.1 Intent
+
+Start issue `#9` on an isolated Git branch before schema, config, or code
+changes begin.
+
+#### 0.2 Files
+
+- No source files are changed by this task.
+
+#### 0.3 Dependencies
+
+None
+
+- [ ] **Step 1:** Check the current Git branch and worktree status.
+- [ ] **Step 2:** Create and switch to `issue-9-sample-user-table`, or the
+      closest repo-consistent available variant if that branch already exists.
+- [ ] **Step 3:** Confirm later task commits will land on the new task branch.
+
+#### 0.4 Verification
+
+- Run: `git branch --show-current`
+- Expect: the task branch is active before implementation starts.
+- Commit: No commit; branch creation itself has no file changes.
+
+### Task 1: Define The Disposable Sample Table
+
+#### 1.1 Intent
+
+Update the early-stage Flyway baseline so the API has a clearly temporary
+`sample_users` table to exercise CRUD flows without implying the final user
+domain model.
+
+#### 1.2 Files
+
+- Modify:
+  `infra/flyway/sql/baseline/V1__baseline.sql`
+
+#### 1.3 Dependencies
+
+Task 0
+
+- [ ] **Step 1:** Replace the generic `users` sample schema with
+      `sample_users`.
+- [ ] **Step 2:** Keep the sample table intentionally small: `id`, `username`,
+      `display_name`, and `created_at`.
+- [ ] **Step 3:** Preserve the existing uniqueness constraint on `username` and
+      timestamp default unless implementation reveals a concrete issue.
+
+#### 1.4 Verification
+
+- Run: `git diff -- infra/flyway/sql/baseline/V1__baseline.sql`
+- Expect: the baseline migration now defines only the disposable
+  `sample_users` table for this CRUD example.
+- Commit: Save the baseline schema rename/update checkpoint.
+
+### Task 2: Enable Spring Boot Virtual Threads
+
+#### 2.1 Intent
+
+Enable Spring Boot's virtual-thread mode for the API runtime with the documented
+single configuration property.
+
+#### 2.2 Files
+
+- Modify:
+  `backend/apps/api/src/main/resources/application.yaml`
+
+#### 2.3 Dependencies
+
+Task 1
+
+- [ ] **Step 1:** Add `spring.threads.virtual.enabled: true` to the API's main
+      application configuration.
+- [ ] **Step 2:** Keep the YAML nested under the existing `spring:` block and
+      avoid unrelated configuration churn.
+
+#### 2.4 Verification
+
+- Run: `git diff -- backend/apps/api/src/main/resources/application.yaml`
+- Expect: the diff is the one-line Spring Boot virtual-thread setting plus only
+  the YAML structure needed to place it.
+- Commit: Save the virtual-thread configuration checkpoint.
+
+### Task 3: Implement SampleUser CRUD
+
+#### 3.1 Intent
+
+Expose simple REST endpoints backed by the `sample_users` database table.
+
+#### 3.2 Files
+
+- Create:
+  `backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserModels.kt`
+- Create:
+  `backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserRepository.kt`
+- Create:
+  `backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserController.kt`
+
+#### 3.3 Dependencies
+
+Tasks 1-2
+
+- [ ] **Step 1:** Model the columns from `sample_users`: `id`, `username`,
+      `display_name`, and `created_at`.
+- [ ] **Step 2:** Implement `JdbcClient` repository methods for create,
+      find by id, list, update, and delete.
+- [ ] **Step 3:** Implement REST endpoints:
+      `POST /sample-users`, `GET /sample-users`, `GET /sample-users/{id}`,
+      `PUT /sample-users/{id}`, and `DELETE /sample-users/{id}`.
+- [ ] **Step 4:** Return sensible HTTP statuses: `201 Created`, `200 OK`,
+      `204 No Content`, `400 Bad Request` for validation failures, and
+      `404 Not Found` for missing IDs.
+- [ ] **Step 5:** Keep validation intentionally minimal with `@NotBlank` and
+      small `@Size` limits on request DTOs.
+
+#### 3.4 Verification
+
+- Run: `cd backend && ./gradlew :apps:api:compileKotlin`
+- Expect: production Kotlin code compiles without new dependencies.
+- Commit: Save the SampleUser CRUD implementation checkpoint.
+
+#### 3.5 Notes
+
+- Update `V1__baseline.sql` directly for `sample_users`; this is acceptable
+  here because the table is intentionally disposable and the project is still
+  very early stage.
+- Prefer not to repurpose production-looking `users` naming for this sample CRUD
+  issue.
+- Prefer `JdbcClient` because the backend already has Spring JDBC and no JPA
+  dependency.
+
+### Task 4: Add Rollback-Safe Integration Tests
+
+#### 4.1 Intent
+
+Add enough tests to prove CRUD behavior while ensuring rows created or modified
+by tests are reverted after each test.
+
+#### 4.2 Files
+
+- Create:
+  `backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/sampleusers/SampleUserControllerIntegrationTests.kt`
+- Reuse if needed:
+  `backend/apps/api/src/test/resources/application-test.yaml`
+
+#### 4.3 Dependencies
+
+Task 3
+
+- [ ] **Step 1:** Use `@SpringBootTest`, `@AutoConfigureMockMvc`,
+      `@ActiveProfiles("test")`, and `@Transactional` so MockMvc requests share
+      the test transaction and are rolled back.
+- [ ] **Step 2:** Use a unique sample username prefix per test run to avoid colliding
+      with local developer data.
+- [ ] **Step 3:** Add a create/read/list test that verifies a created sample user can
+      be fetched and appears in the list.
+- [ ] **Step 4:** Add an update/delete test that verifies editable fields change
+      and the deleted sample user returns `404` afterward.
+- [ ] **Step 5:** Add a small validation or not-found test if it stays cheap and
+      does not make the test suite noisy.
+- [ ] **Step 6:** Add an `@AfterTransaction` assertion that no rows matching the
+      test-run username prefix remain after rollback.
+
+#### 4.4 Verification
+
+- Run: `mise //backend/docker:run --rm api :apps:api:test`
+- Expect: all API tests pass against the Compose PostgreSQL service and the
+  rollback assertion proves test data did not persist.
+- Commit: Save the rollback-safe SampleUser integration tests checkpoint.
+
+#### 4.5 Notes
+
+- Transaction rollback does not reset PostgreSQL sequences, and that is okay;
+  the important part is that test rows and updates are gone.
+- Tests should not assert exact global user count because a developer's local
+  database may contain unrelated rows.
+
+### Task 5: Confirm CI Already Runs The New Tests
+
+#### 5.1 Intent
+
+Make sure the GitHub Actions backend check will execute the new tests without
+unnecessary CI churn.
+
+#### 5.2 Files
+
+- Review:
+  `.github/workflows/backend-check.yml`
+- Modify only if needed:
+  `.github/workflows/backend-check.yml`
+
+#### 5.3 Dependencies
+
+Task 4
+
+- [ ] **Step 1:** Confirm backend path filters include the changed backend test
+      files.
+- [ ] **Step 2:** Confirm the workflow still runs
+      `mise //backend/docker:run --rm api :apps:api:test` after starting
+      Compose dependencies and Flyway.
+- [ ] **Step 3:** Avoid workflow edits if the current CI command already covers
+      the new tests.
+
+#### 5.4 Verification
+
+- Run: `mise //backend/docker:config-check`
+- Run: `mise //backend/docker:run --rm api :apps:api:test`
+- Expect: the same command CI uses passes locally.
+- Commit: Save CI workflow changes only if Task 5 requires an actual workflow
+  edit; if no files change, record that no Task 5 commit is needed.
+
+### Task 6: Final Review
+
+#### 6.1 Intent
+
+Keep the final change easy to review and aligned with the issue.
+
+#### 6.2 Files
+
+- Review all changed files from `git status --short`
+
+#### 6.3 Dependencies
+
+Tasks 0-5
+
+- [ ] **Step 1:** Review `git diff` for accidental generated files or unrelated
+      formatting churn.
+- [ ] **Step 2:** Confirm all new public classes/functions have KDoc.
+- [ ] **Step 3:** Summarize any deliberate non-changes, especially if CI did not
+      need a workflow edit.
+
+#### 6.4 Verification
+
+- Run: `git status --short`
+- Expect: only intended source/test files, and possibly CI if Task 5 found a
+  real gap.
+- Commit: Save final review-only fixes only if Task 6 produces file changes; do
+  not create an empty commit.
+
+## References
+<!-- list of references, such as files, urls, or other resources -->
+
+<!-- markdownlint-disable MD013 -->
+
+| Resouce | Description | Other Notes if any |
+| --- | --- | --- |
+| [GitHub issue #9](https://github.com/CXwudi/nijigen-video-site/issues/9) | Source issue: add CRUD for a user table, tests, and CI coverage. | Must Read |
+| [Spring Boot virtual threads docs](https://docs.spring.io/spring-boot/reference/features/spring-application.html) | Official Spring Boot 4 reference for `spring.threads.virtual.enabled=true`. | Important |
+| ![a file](../../infra/flyway/sql/baseline/V1__baseline.sql) | Existing Flyway baseline to modify for the disposable `sample_users` table. | Must Read |
+| ![a file](../../backend/apps/api/build.gradle.kts) | API module dependencies; confirms Spring JDBC/WebMVC/test stack. | Important |
+| ![a file](../../backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiApp.kt) | API Spring Boot application package root and conventions. | Important |
+| ![a file](../../backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt) | Existing bootstrap test style for the API module. | |
+| ![a file](../../.github/workflows/backend-check.yml) | Backend CI workflow that should run the new tests. | Important |
+| ![a file](../../backend/docker/mise.toml) | Local/CI backend Compose task definitions used to run API tests. | Important |
+
+<!-- markdownlint-enable MD013 -->

--- a/design-log/plans/plan-issue-9-sample-user-table-20260512.md
+++ b/design-log/plans/plan-issue-9-sample-user-table-20260512.md
@@ -301,11 +301,11 @@ Tasks 0-5
 | --- | --- | --- |
 | [GitHub issue #9](https://github.com/CXwudi/nijigen-video-site/issues/9) | Source issue: add CRUD for a user table, tests, and CI coverage. | Must Read |
 | [Spring Boot virtual threads docs](https://docs.spring.io/spring-boot/reference/features/spring-application.html) | Official Spring Boot 4 reference for `spring.threads.virtual.enabled=true`. | Important |
-| ![a file](../../infra/flyway/sql/baseline/V1__baseline.sql) | Existing Flyway baseline to modify for the disposable `sample_users` table. | Must Read |
-| ![a file](../../backend/apps/api/build.gradle.kts) | API module dependencies; confirms Spring JDBC/WebMVC/test stack. | Important |
-| ![a file](../../backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiApp.kt) | API Spring Boot application package root and conventions. | Important |
-| ![a file](../../backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt) | Existing bootstrap test style for the API module. | |
-| ![a file](../../.github/workflows/backend-check.yml) | Backend CI workflow that should run the new tests. | Important |
-| ![a file](../../backend/docker/mise.toml) | Local/CI backend Compose task definitions used to run API tests. | Important |
+| [a file](../../infra/flyway/sql/baseline/V1__baseline.sql) | Existing Flyway baseline to modify for the disposable `sample_users` table. | Must Read |
+| [a file](../../backend/apps/api/build.gradle.kts) | API module dependencies; confirms Spring JDBC/WebMVC/test stack. | Important |
+| [a file](../../backend/apps/api/src/main/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiApp.kt) | API Spring Boot application package root and conventions. | Important |
+| [a file](../../backend/apps/api/src/test/kotlin/io/github/cxwudi/nijigenvideosite/apps/api/ApiAppTests.kt) | Existing bootstrap test style for the API module. | |
+| [a file](../../.github/workflows/backend-check.yml) | Backend CI workflow that should run the new tests. | Important |
+| [a file](../../backend/docker/mise.toml) | Local/CI backend Compose task definitions used to run API tests. | Important |
 
 <!-- markdownlint-enable MD013 -->

--- a/infra/flyway/sql/baseline/V1__baseline.sql
+++ b/infra/flyway/sql/baseline/V1__baseline.sql
@@ -1,4 +1,4 @@
-CREATE TABLE users (
+CREATE TABLE sample_users (
   id BIGSERIAL PRIMARY KEY,
   username TEXT NOT NULL UNIQUE,
   display_name TEXT NOT NULL,

--- a/infra/flyway/sql/baseline/V1__baseline.sql
+++ b/infra/flyway/sql/baseline/V1__baseline.sql
@@ -1,8 +1,8 @@
 CREATE TABLE sample_users (
   id BIGSERIAL PRIMARY KEY,
-  username TEXT NOT NULL UNIQUE,
-  email TEXT NOT NULL UNIQUE,
-  display_name TEXT NOT NULL,
-  bio TEXT,
+  username TEXT NOT NULL UNIQUE CHECK (char_length(username) <= 64),
+  email TEXT NOT NULL UNIQUE CHECK (char_length(email) <= 255),
+  display_name TEXT NOT NULL CHECK (char_length(display_name) <= 120),
+  bio TEXT CHECK (bio IS NULL OR char_length(bio) <= 500),
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/infra/flyway/sql/baseline/V1__baseline.sql
+++ b/infra/flyway/sql/baseline/V1__baseline.sql
@@ -1,6 +1,8 @@
 CREATE TABLE sample_users (
   id BIGSERIAL PRIMARY KEY,
   username TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL UNIQUE,
   display_name TEXT NOT NULL,
+  bio TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- add disposable `sample_users` Flyway baseline table with sample profile fields
- enable Spring Boot virtual threads for the API runtime
- add `JdbcClient`-backed SampleUser CRUD endpoints and rollback-safe integration tests
- add a backend Docker task reminder to stop dependent services after one-off runs

## Verification
- `./gradlew :apps:api:compileKotlin :apps:api:compileTestKotlin`
- `mise //backend/docker:run --rm api :apps:api:test --tests io.github.cxwudi.nijigenvideosite.apps.api.sampleusers.SampleUserControllerIntegrationTests`

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sample user management API with complete CRUD functionality (create, retrieve, list, update, delete) via REST endpoints under `/sample-users`.

* **Tests**
  * Added comprehensive integration tests verifying sample user API operations and transactional data handling.

* **Chores**
  * Enabled virtual threads in application configuration for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CXwudi/nijigen-video-site/pull/20)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->