### PR TITLE
Centralize runtime versions from mise into Docker and CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,12 +29,12 @@
       enabled: false,
     },
     {
-      description: 'Keep Java version catalog entries manual because they must stay aligned with Docker and compose files.',
+      description: 'Keep the Java version catalog fallback manual because it must stay aligned with root JDK_VERSION.',
       matchDepNames: ['java'],
       enabled: false,
     },
     {
-      description: 'Keep BellSoft Java container image updates manual because their tags encode the Java version.',
+      description: 'Keep BellSoft Java container upgrades manual; Dockerfiles receive the Java major from root JDK_VERSION.',
       matchDatasources: ['docker'],
       matchPackageNames: [
         'ghcr.io/bell-sw/hardened-liberica-native-image-kit-container',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,10 @@
   includePaths: [
     'backend/**',
     'frontend/**',
+    'infra/**',
+    'mise.toml',
+    '.github/workflows/**',
+    '.github/renovate.json5',
   ],
   packageRules: [
     {
@@ -22,24 +26,23 @@
       groupName: 'all dependencies',
       groupSlug: 'all-deps',
     },
+    // Keep centralized runtime versions manual.
     {
-      description: 'Keep Java toolchain versions manual everywhere Renovate can detect them.',
+      description: 'Keep JDK upgrades manual if Renovate can detect a version declaration.',
       matchDatasources: ['java-version'],
       matchPackageNames: ['java-jdk', 'java-jre'],
       enabled: false,
     },
     {
-      description: 'Keep the Java version catalog fallback manual because it must stay aligned with root JDK_VERSION.',
-      matchDepNames: ['java'],
+      description: 'Keep Node.js upgrades manual if Renovate can detect a version declaration.',
+      matchDatasources: ['node-version'],
+      matchPackageNames: ['node'],
       enabled: false,
     },
     {
-      description: 'Keep BellSoft Java container upgrades manual; Dockerfiles receive the Java major from root JDK_VERSION.',
-      matchDatasources: ['docker'],
-      matchPackageNames: [
-        'ghcr.io/bell-sw/hardened-liberica-native-image-kit-container',
-        'ghcr.io/bell-sw/hardened-liberica-runtime-container',
-      ],
+      description: 'Keep pnpm upgrades manual if Renovate can detect a version declaration.',
+      matchDatasources: ['npm'],
+      matchPackageNames: ['pnpm'],
       enabled: false,
     },
   ],

--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -77,6 +77,20 @@ jobs:
       - name: 'Render frontend Compose stack'
         run: 'mise //frontend/docker:config-check'
 
+      - name: 'Resolve frontend runtime versions'
+        id: 'runtime_versions'
+        run: |
+          node_version="$(mise exec -- printenv NODE_VERSION)"
+          pnpm_version="$(mise exec -- printenv PNPM_VERSION)"
+          if [[ -z "${node_version}" || -z "${pnpm_version}" ]]; then
+            echo '::error::NODE_VERSION and PNPM_VERSION must resolve through mise.'
+            exit 1
+          fi
+          {
+            echo "node_version=${node_version}"
+            echo "pnpm_version=${pnpm_version}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: 'Build frontend pnpm image'
         uses: 'docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8'
         with:
@@ -85,6 +99,9 @@ jobs:
           target: 'web-pnpm-base'
           tags: 'nijigen-video-site-web-pnpm:local'
           load: true
+          build-args: |
+            NODE_VERSION=${{ steps.runtime_versions.outputs.node_version }}
+            PNPM_VERSION=${{ steps.runtime_versions.outputs.pnpm_version }}
           cache-from: 'type=gha,scope=frontend-web'
           cache-to: 'type=gha,scope=frontend-web,mode=max'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<ProjectPrompt>
 Please read:
 
 @README.md
+</ProjectPrompt>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
+<ProjectPrompt>
 @README.md
+</ProjectPrompt>

--- a/backend/docker/.env.example
+++ b/backend/docker/.env.example
@@ -2,8 +2,6 @@
 
 COMPOSE_PROJECT_NAME=nijigen-video-site-backend
 
-JDK_VERSION=25
-
 POSTGRES_DB=nijigen_video_site
 POSTGRES_USER=nijigen
 POSTGRES_PASSWORD=nijigen

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,10 +1,12 @@
 # syntax=docker/dockerfile:1
 
+ARG JDK_VERSION
+
 ## Shared Gradle build stage
 
-# If we changed this image, also update it in the compose files
-# TODO: how to make Java version unified? using mise and env var?
-FROM ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-25-nik-25-glibc AS gradle-base
+FROM ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION}-nik-${JDK_VERSION}-glibc AS gradle-base
+ARG JDK_VERSION
+ENV JDK_VERSION="${JDK_VERSION}"
 WORKDIR /workspace/backend
 COPY . /workspace/backend/
 RUN chmod 0755 gradlew
@@ -26,7 +28,7 @@ RUN set -eux; \
     test -n "$dist_dir"; \
     cp -R "$dist_dir"/. /workspace/dist/app/
 
-FROM ghcr.io/bell-sw/hardened-liberica-runtime-container:jre-25-crac-glibc AS api-jvm-runtime
+FROM ghcr.io/bell-sw/hardened-liberica-runtime-container:jre-${JDK_VERSION}-crac-glibc AS api-jvm-runtime
 # TODO(new issue, optional): investigate and configure CRAC
 WORKDIR /app
 COPY --from=api-jvm-build /workspace/dist/app/ /app/

--- a/backend/docker/compose.local.yml
+++ b/backend/docker/compose.local.yml
@@ -18,7 +18,7 @@ services:
     extends:
       file: ../../infra/compose/common-services.yml
       service: api-compose-base
-    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:-25}-nik-${JDK_VERSION:-25}-glibc
+    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided}-nik-${JDK_VERSION:?JDK_VERSION must be provided}-glibc
     profiles:
       - jetbrains
     ports:

--- a/backend/docker/compose.local.yml
+++ b/backend/docker/compose.local.yml
@@ -18,7 +18,7 @@ services:
     extends:
       file: ../../infra/compose/common-services.yml
       service: api-compose-base
-    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided}-nik-${JDK_VERSION:?JDK_VERSION must be provided}-glibc
+    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}-nik-${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}-glibc
     profiles:
       - jetbrains
     ports:

--- a/backend/docs/gradle-setup-explain.md
+++ b/backend/docs/gradle-setup-explain.md
@@ -20,7 +20,7 @@ The backend root is intentionally thin:
 - dependency coordinates
 - plugin coordinates
 
-The catalog is shared by the main backend build and the internal plugin build. The root `mise.toml` normally supplies the Java version through `JDK_VERSION`; the internal plugin build overlays that value on the imported catalog. When Gradle is invoked without `JDK_VERSION`, the Java version in `gradle/libs.versions.toml` remains the compatibility fallback.
+The catalog is shared by the main backend build and the internal plugin build.
 
 When a BOM is cataloged, it becomes the source of truth for the versions it manages, so those libraries should not also get individual catalog entries.
 

--- a/backend/docs/gradle-setup-explain.md
+++ b/backend/docs/gradle-setup-explain.md
@@ -20,9 +20,9 @@ The backend root is intentionally thin:
 - dependency coordinates
 - plugin coordinates
 
-The catalog is shared by the main backend build and the internal plugin build.
-When a BOM is cataloged, it becomes the source of truth for the versions it
-manages, so those libraries should not also get individual catalog entries.
+The catalog is shared by the main backend build and the internal plugin build. The root `mise.toml` normally supplies the Java version through `JDK_VERSION`; the internal plugin build overlays that value on the imported catalog. When Gradle is invoked without `JDK_VERSION`, the Java version in `gradle/libs.versions.toml` remains the compatibility fallback.
+
+When a BOM is cataloged, it becomes the source of truth for the versions it manages, so those libraries should not also get individual catalog entries.
 
 ## Internal Plugin Build
 

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Add a version here only when it is reused in more than one place.
 # Keep single-use versions inline in the entry itself for clarity.
-java = "25" # If this is changed, make sure to also update the Dockerfile and related compose files.
+java = "25" # Keep aligned with JDK_VERSION in root mise.toml; this value is the Gradle fallback.
 kotlin = "2.4.0"
 spring-boot = "4.1.0"
 graalvm-native = "1.1.3"

--- a/backend/gradle/plugins/settings.gradle.kts
+++ b/backend/gradle/plugins/settings.gradle.kts
@@ -7,6 +7,10 @@ dependencyResolutionManagement {
   versionCatalogs {
     create("libs") {
       from(files("../libs.versions.toml"))
+
+      providers.environmentVariable("JDK_VERSION")
+        .orNull
+        ?.let { version("java", it) }
     }
   }
 }

--- a/backend/gradle/plugins/settings.gradle.kts
+++ b/backend/gradle/plugins/settings.gradle.kts
@@ -8,6 +8,7 @@ dependencyResolutionManagement {
     create("libs") {
       from(files("../libs.versions.toml"))
 
+      // Override the catalog fallback when mise provides JDK_VERSION.
       providers.environmentVariable("JDK_VERSION")
         .orNull
         ?.let { version("java", it) }

--- a/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
+++ b/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
@@ -1,0 +1,253 @@
+# Issue 34 Mise-to-Docker Version Control Implementation Plan
+
+**Goal:** Make root `mise.toml` the primary version source for JDK 25, Node.js 24, and pnpm 11 across host tools, Gradle, Dockerfiles, Compose, and CI while preserving Java 25 in the Gradle catalog as the direct-Gradle fallback.
+
+**Source of Truth:** [GitHub issue #34](https://github.com/CXwudi/nijigen-video-site/issues/34), the user's decisions that `PNPM_VERSION` is major version 11 and the included Gradle build should overlay `JDK_VERSION` on its imported TOML catalog while retaining the catalog value as fallback, and the current repository Docker/environment conventions.
+
+**Scope:** Includes JDK, Node.js, and pnpm version declarations and every current consumer of those versions. It also includes required Compose, CI, env-template, and documentation updates. It excludes unrelated image names such as `WEB_PNPM_IMAGE`, application dependency versions, and changing the existing major-version pinning policy to exact patch versions.
+
+**Approach:** Declare `JDK_VERSION=25`, `NODE_VERSION=24`, and `PNPM_VERSION=11` under root mise `[env]`, then reference those values from mise's `[tools]`. Pass the exported values explicitly across process boundaries: Compose interpolation supplies image tags, container environment, and build arguments; Dockerfiles consume `ARG`s; the included Gradle build conditionally overrides its imported `java` catalog version from `JDK_VERSION`; and the frontend workflow exposes step outputs to the Docker build action.
+
+**Verification:** Validate mise's resolved environment and tool versions, render all three Compose entrypoints, run backend and frontend checks, build the affected Docker targets, and inspect the resulting Java, Node.js, and pnpm major versions.
+
+---
+
+## Key Design Decisions
+
+- Root `mise.toml` owns the normal JDK, Node.js, and pnpm version policies. Component `.env` files no longer duplicate them; Java 25 remains in `libs.versions.toml` only as the direct-Gradle fallback.
+- Keep major-version semantics: JDK 25, Node.js 24, and pnpm 11 may resolve to newer compatible patch releases.
+- Dockerfiles declare version `ARG`s without independent numeric defaults. A missing bridge should fail instead of silently drifting back to a duplicated version.
+- Compose uses required interpolation such as `${JDK_VERSION:?JDK_VERSION must be provided}`. Commands launched through mise receive the values automatically, while direct Docker builds must pass the documented `--build-arg` values.
+- The included plugin build imports `libs.versions.toml`, then conditionally overwrites its `java` alias from `JDK_VERSION`. If the environment variable is absent, the imported Java 25 value remains in effect.
+- `backend/gradle/plugins/version-catalog/build.gradle.kts` and the `my.jvm-common.gradle.kts` precompiled script plugin remain unchanged; they continue consuming the generated `Versions.Java` value.
+- `WEB_PNPM_IMAGE` remains in the frontend env template because it names a locally built image; it does not select the pnpm release inside that image.
+
+## File Impact Map
+
+- `mise.toml`: own and export all three versions; derive mise tools from them.
+- `backend/gradle/plugins/settings.gradle.kts`: import the existing TOML catalog and conditionally overlay its `java` alias from `JDK_VERSION`.
+- `backend/gradle/libs.versions.toml`: retain Java 25 as the fallback when Gradle is invoked without the mise environment; no implementation change is needed.
+- `backend/docker/Dockerfile` and `frontend/docker/Dockerfile`: parameterize all version-bearing image tags and Node installation commands.
+- `infra/compose/common-dev-services.yml`, `backend/docker/compose.local.yml`, and `infra/compose/compose.prod.yml`: bridge mise values into image tags, container environment, and Docker build arguments.
+- `backend/docker/.env.example`, `frontend/docker/.env.example`, and `infra/compose/prod.env.example`: remove duplicated language-version values.
+- `.github/workflows/frontend-check.yml`: pass mise-derived Node.js and pnpm versions into the Docker build action without copying numeric values into workflow YAML.
+- `.github/renovate.json5`: revise Java-specific guidance so the catalog is the intentional direct-Gradle fallback and literal Docker tags are no longer the synchronization mechanism.
+- `docs/environment-setup.md`, `docs/docker-setup-explain.md`, and `backend/docs/gradle-setup-explain.md`: document ownership and invocation contracts.
+
+## Task Steps
+
+When executing the plan:
+
+- mark `[ ]` boxes as completed `[x]` when an item is completed
+- after each task, do a code review by spawning another subagent, and fix any valuable feedback
+- before moving to the next task, commit the changes
+
+### Task 1: Establish mise with a Gradle Catalog Fallback
+
+#### 1.1 Intent
+
+Create one exported version policy for normal workflows and connect the included Gradle build to it without breaking direct Gradle usage.
+
+#### 1.2 Files
+
+- Modify: `mise.toml`
+- Modify: `backend/gradle/plugins/settings.gradle.kts`
+- Modify: `backend/docs/gradle-setup-explain.md`
+
+#### 1.3 Dependencies
+
+None.
+
+- [ ] **Step 1:** Add root `[env]` entries for `JDK_VERSION="25"`, `NODE_VERSION="24"`, and `PNPM_VERSION="11"`.
+- [ ] **Step 2:** Change `[tools]` so Java, Node.js, and pnpm use mise templates referencing the corresponding exported variables; keep unrelated tools unchanged.
+- [ ] **Step 3:** In `backend/gradle/plugins/settings.gradle.kts`, keep the existing single `from(files("../libs.versions.toml"))` import and conditionally call `version("java", value)` only when `providers.environmentVariable("JDK_VERSION")` is present. Let the imported `versions.java` value remain untouched when the variable is absent.
+- [ ] **Step 4:** Leave `backend/gradle/libs.versions.toml`, the generated `Versions.Java` adapter in `backend/gradle/plugins/version-catalog/build.gradle.kts`, and `backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts` unchanged.
+- [ ] **Step 5:** Update the Gradle setup documentation to identify root `mise.toml` as the normal Java version owner and `libs.versions.toml` as the compatibility fallback for Gradle commands invoked without `JDK_VERSION`.
+
+#### 1.4 Verification
+
+- Run: `mise env --json`
+- Expect: `JDK_VERSION=25`, `NODE_VERSION=24`, and `PNPM_VERSION=11` are present.
+- Run: `mise current java && mise current node && mise current pnpm`
+- Expect: resolved tools use JDK 25, Node.js 24, and pnpm 11 patch releases.
+- Run: `mise //backend:gradle javaToolchains`
+- Expect: the included catalog overlay generates `Versions.Java` as 25 and Gradle configures a Java 25 native-image-capable toolchain.
+- Run: `env -u JDK_VERSION ./backend/gradlew -p backend help --rerun-tasks`
+- Run: `rg 'Java: Int = 25' backend/gradle/plugins/version-catalog/build/generated/sources/buildConfig/main/my/catalog/Versions.kt`
+- Expect: direct Gradle use succeeds and generates Java 25 from the TOML fallback.
+- Run: `JDK_VERSION=24 ./backend/gradlew -p backend help --rerun-tasks`
+- Run: `rg 'Java: Int = 24' backend/gradle/plugins/version-catalog/build/generated/sources/buildConfig/main/my/catalog/Versions.kt`
+- Expect: a supplied environment value overrides the imported catalog version, proving the overlay path independently of the normal value 25.
+- Run: `mise //backend:gradle help --rerun-tasks`
+- Expect: the generated source is restored to Java 25 after the override test.
+
+#### 1.5 Notes
+
+- Use mise's documented `{{ env.VARIABLE_NAME }}` template form; do not copy the numeric values back into `[tools]`.
+- Gradle documents combining one `from(...)` import with programmatic `version(...)` calls as the supported way to override an imported version.
+- Do not create a second `libs` catalog in `backend/settings.gradle.kts`; the main build already auto-imports `gradle/libs.versions.toml`. The targeted overlay belongs in the included plugin build, where the catalog is explicitly imported.
+
+### Task 2: Bridge Versions Through Docker and Compose
+
+#### 2.1 Intent
+
+Make every development and production-like image consume the mise-owned values through explicit Docker/Compose boundaries.
+
+#### 2.2 Files
+
+- Modify: `backend/docker/Dockerfile`
+- Modify: `frontend/docker/Dockerfile`
+- Modify: `infra/compose/common-dev-services.yml`
+- Modify: `backend/docker/compose.local.yml`
+- Modify: `infra/compose/compose.prod.yml`
+- Modify: `backend/docker/.env.example`
+- Modify: `frontend/docker/.env.example`
+- Modify: `infra/compose/prod.env.example`
+
+#### 2.3 Dependencies
+
+Task 1.
+
+- [ ] **Step 1:** Add a global `JDK_VERSION` build argument to the backend Dockerfile and substitute it into the NIK builder and JVM runtime tags. Expose the same value inside `gradle-base` so Gradle toolchain configuration sees it during JVM and native builds.
+- [ ] **Step 2:** Add global `PNPM_VERSION` and `NODE_VERSION` arguments to the frontend Dockerfile. Use them for the pnpm base tag, `pnpm runtime set node`, and the hardened Node.js runtime tag.
+- [ ] **Step 3:** In the shared development Compose file, require `JDK_VERSION` for the API development image, pass it into the API container, and pass required Node.js/pnpm build args into `web-pnpm-base`.
+- [ ] **Step 4:** Require `JDK_VERSION` in the JetBrains API image reference in backend local Compose. Do not add it to that container's environment: IntelliJ replaces this minimal service's entrypoint and mounts built jars, so Gradle does not evaluate the project inside `api-jb`.
+- [ ] **Step 5:** Add required JDK build args to the production-like API build and required Node.js/pnpm build args to its web build.
+- [ ] **Step 6:** Remove `JDK_VERSION` from all three checked-in env templates; do not add Node.js or pnpm versions to them. Retain deployment settings, credentials, ports, runtime targets, and `WEB_PNPM_IMAGE` unchanged.
+- [ ] **Step 7:** Refresh ignored local env files from their templates when needed for verification, preserving any developer-specific credentials or port overrides instead of overwriting them blindly.
+
+#### 2.4 Verification
+
+- Run: `mise //backend/docker:config-check`
+- Run: `mise //frontend/docker:config-check`
+- Run: `mise //infra/compose:config-check`
+- Expect: all Compose models render with JDK 25, Node.js 24, and pnpm 11 in the appropriate image names, container environment, and build args even though the env templates no longer declare them.
+- Run: `env -u JDK_VERSION HOST_UID="$(id -u)" HOST_GID="$(id -g)" HOST_GRADLE_USER_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}" docker compose --env-file backend/docker/.env.example -f backend/docker/compose.local.yml --profile backend config --quiet`
+- Expect: direct Compose use without mise fails with the actionable required `JDK_VERSION` interpolation message.
+- Run: `mise exec -- bash -c 'docker build --build-arg JDK_VERSION="$JDK_VERSION" -f backend/docker/Dockerfile --target gradle-base -t nijigen-gradle-base:verify backend'`
+- Run: `docker run --rm --entrypoint java nijigen-gradle-base:verify -version`
+- Expect: the backend builder reports Java 25.
+- Run: `mise exec -- bash -c 'docker build --build-arg NODE_VERSION="$NODE_VERSION" --build-arg PNPM_VERSION="$PNPM_VERSION" -f frontend/docker/Dockerfile --target web-pnpm-base -t nijigen-web-pnpm:verify frontend'`
+- Run: `docker run --rm --entrypoint node nijigen-web-pnpm:verify --version`
+- Run: `docker run --rm --entrypoint pnpm nijigen-web-pnpm:verify --version`
+- Expect: the frontend builder reports Node.js 24.x and pnpm 11.x.
+- Run: `mise exec -- bash -c 'docker build --build-arg JDK_VERSION="$JDK_VERSION" -f backend/docker/Dockerfile --target api-jvm-runtime -t nijigen-api-jvm:verify backend'`
+- Run: `docker run --rm --entrypoint java nijigen-api-jvm:verify -version`
+- Expect: the parameterized JVM runtime stage builds and reports Java 25.
+- Run: `mise exec -- bash -c 'docker build --build-arg NODE_VERSION="$NODE_VERSION" --build-arg PNPM_VERSION="$PNPM_VERSION" -f frontend/docker/Dockerfile --target web-runtime -t nijigen-web:verify frontend'`
+- Run: `docker run --rm --entrypoint node nijigen-web:verify --version`
+- Expect: the parameterized hardened runtime stage builds and reports Node.js 24.x.
+
+#### 2.5 Notes
+
+- A shell variable does not cross a Docker build boundary by itself. Compose `build.args` or CLI `--build-arg` must connect it to a Dockerfile `ARG`.
+- Declare global Dockerfile arguments before the first `FROM`; redeclare an argument within a stage when build instructions in that stage need its value.
+
+### Task 3: Keep CI and Maintenance Metadata on the Same Path
+
+#### 3.1 Intent
+
+Prevent CI from bypassing the version bridge and remove maintenance guidance that would send future updates to literal Docker tags instead of the mise policy and intentional Gradle fallback.
+
+#### 3.2 Files
+
+- Modify: `.github/workflows/frontend-check.yml`
+- Modify: `.github/renovate.json5`
+
+#### 3.3 Dependencies
+
+Task 2.
+
+- [ ] **Step 1:** Add a frontend workflow step that reads `NODE_VERSION` and `PNPM_VERSION` through `mise exec`, validates that both are non-empty, and publishes them as step outputs or `GITHUB_ENV` values.
+- [ ] **Step 2:** Pass those derived values to `docker/build-push-action` using its `build-args` input. Do not place `24` or `11` directly in workflow YAML.
+- [ ] **Step 3:** Update Renovate comments so the disabled Java catalog rule is described as protecting the direct-Gradle fallback, which must be kept aligned manually with root `JDK_VERSION`; remove references to literal BellSoft tags as the synchronization mechanism. Keep major language-runtime upgrades manual unless issue #34 explicitly expands into dependency automation.
+
+#### 3.4 Verification
+
+- Run: `mise x actionlint@latest -- actionlint .github/workflows/frontend-check.yml`
+- Expect: the workflow syntax and step-output references are valid.
+- Run the workflow's version-export shell snippet locally with a temporary `GITHUB_OUTPUT` file.
+- Expect: it emits Node.js `24` and pnpm `11` from mise without hard-coded workflow values.
+- Run: `mise //frontend/docker:config-check`
+- Expect: the workflow-oriented frontend Compose path still renders.
+
+#### 3.5 Notes
+
+- Prefer step outputs for the Docker action because GitHub expression inputs do not inherit a preceding shell process's environment automatically.
+- Do not replace the existing Buildx action with a plain Docker command; retain its cache configuration.
+
+### Task 4: Document and Integrate the Unified Workflow
+
+#### 4.1 Intent
+
+Make the new ownership model discoverable and verify the repository as a whole.
+
+#### 4.2 Files
+
+- Modify: `docs/environment-setup.md`
+- Modify: `docs/docker-setup-explain.md`
+
+#### 4.3 Dependencies
+
+Tasks 1 through 3.
+
+- [ ] **Step 1:** Document root `mise.toml` as the normal place to change JDK, Node.js, or pnpm major versions and list the downstream consumers. For a JDK upgrade, also update the intentional `libs.versions.toml` fallback in the same change.
+- [ ] **Step 2:** Explain that mise activation or `mise exec`/mise tasks exports versions to Compose, while standalone `docker build` calls must pass the corresponding build args.
+- [ ] **Step 3:** Document Compose shell-over-env-file precedence so developers understand why local and production env templates no longer own runtime versions.
+- [ ] **Step 4:** Search for stale literal version declarations and comments; enumerate and review every remaining match. Retain literals only in root `mise.toml`, the intentional Gradle catalog fallback, immutable historical design logs, or documentation and verification examples that are not active configuration sources.
+
+#### 4.4 Verification
+
+- Run: `rg -n --hidden --glob '!.git/**' --glob '!design-log/**' --glob '!**/node_modules/**' '(JDK_VERSION.?=.?25|java.?=.?"25"|runtime set node 24|pnpm/pnpm:latest|hardened-nodejs:24|jdk-25|jre-25|versions\.java)' .`
+- Expect: every remaining match is explicitly accepted as the root declaration, the Gradle fallback/overlay, or a non-configuration example; no unintended duplicate declaration remains.
+- Run: `mise //:docs-link-check`
+- Expect: all local documentation links pass.
+- Run: `mise //backend/docker:run --rm api :apps:api:test`
+- Run: `mise //frontend/docker:run --rm --no-deps web-init`
+- Run: `mise //frontend/docker:run --rm --no-deps web --filter web format:check`
+- Run: `mise //frontend/docker:run --rm --no-deps web --filter web lint`
+- Run: `mise //frontend/docker:run --rm --no-deps web --filter web typecheck`
+- Run: `mise //frontend/docker:run --rm web --filter web test`
+- Run: `mise //frontend/docker:run --rm --no-deps web --filter web build`
+- Expect: backend and frontend checks pass using images derived from the root version policy.
+
+#### 4.5 Notes
+
+- Clean both Compose stacks with their existing `down` tasks after integration verification.
+- Historical files under `design-log/` are immutable records and are not migration targets.
+
+## Risks and Guardrails
+
+- Missing mise activation: direct Compose invocation fails on required version interpolation, while direct Gradle invocation intentionally falls back to `libs.versions.toml`. Supported tasks run under mise and receive `[env]` automatically.
+- JDK fallback drift: root `JDK_VERSION` and `libs.versions.java` are two checked-in values by design. Documentation, Renovate guidance, and verification of both paths must keep their normal values aligned.
+- Docker `ARG` scope: a global argument works in `FROM` but must be redeclared in a stage before it can be used by `ENV` or `RUN`.
+- Compose precedence: the invoking shell overrides `--env-file`; verify this with `docker compose config --environment` rather than relying only on visual inspection of YAML.
+- IDE behavior: Gradle sync outside a mise-activated shell uses the catalog fallback. The JetBrains Compose service still requires the root version for its image tag, but does not evaluate Gradle inside that container.
+- Floating patches: major pins intentionally allow patch advancement. Exact reproducibility would require a separate decision to pin full versions.
+
+## References
+
+| Resource | Description | Other Notes if any |
+| --- | --- | --- |
+| [GitHub issue #34](https://github.com/CXwudi/nijigen-video-site/issues/34) | Requests unified JDK, Node.js, and pnpm versions flowing from mise to Docker. | Must Read |
+| ![Root mise configuration](../../mise.toml) | Current host tool declarations and future primary owner of exported runtime versions. | Must Read |
+| ![Backend Dockerfile](../../backend/docker/Dockerfile) | Contains literal JDK 25 builder and runtime tags. | Must Read |
+| ![Frontend Dockerfile](../../frontend/docker/Dockerfile) | Contains the floating pnpm image and literal Node.js 24 build/runtime selections. | Must Read |
+| ![Shared development services](../../infra/compose/common-dev-services.yml) | Owns the backend development JDK image and frontend Docker build definition. | Must Read |
+| ![Backend local Compose](../../backend/docker/compose.local.yml) | Contains the JetBrains-specific JDK image consumer. | Important |
+| ![Production-like Compose](../../infra/compose/compose.prod.yml) | Builds both application runtime images and must forward version args. | Important |
+| ![Included plugin build settings](../../backend/gradle/plugins/settings.gradle.kts) | Imports the TOML catalog and is the selected boundary for the conditional `JDK_VERSION` overlay. | Must Read |
+| ![Backend Java version catalog](../../backend/gradle/libs.versions.toml) | Retains Java 25 as the direct-Gradle fallback. | Important |
+| ![Version-catalog adapter](../../backend/gradle/plugins/version-catalog/build.gradle.kts) | Continues generating `Versions.Java` from the resolved catalog without modification. | Important |
+| ![Backend JVM convention plugin](../../backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts) | Continues consuming the generated Java value without modification. | Important |
+| ![Frontend CI workflow](../../.github/workflows/frontend-check.yml) | Builds the pnpm image outside Compose and therefore needs an explicit version bridge. | Important |
+| [mise environments](https://mise.jdx.dev/environments/) | Documents `[env]`, task/exec export behavior, and shell activation. | Must Read |
+| [mise templates](https://mise.jdx.dev/templates.html) | Documents referencing `[env]` values from `[tools]`. | Must Read |
+| [Docker build variables](https://docs.docker.com/build/building/variables/) | Defines `ARG`/`ENV` behavior and multi-stage scope. | Must Read |
+| [Compose build specification](https://docs.docker.com/reference/compose-file/build/) | Defines Compose `build.args`. | Important |
+| [Compose interpolation](https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/) | Defines shell and `--env-file` interpolation precedence and inspection commands. | Important |
+| [Gradle build environment](https://docs.gradle.org/current/userguide/build_environment.html) | Documents lazy environment access through `providers.environmentVariable()`. | Important |
+| [Gradle version catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html#sec:overwriting-catalog-versions) | Documents combining `from(...)` with programmatic version overrides. | Must Read |
+| [Gradle JVM toolchains](https://docs.gradle.org/current/userguide/toolchains.html) | Documents Java language-version selection and `javaToolchains` verification. | Important |
+| [GitHub Actions outputs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs) | Documents publishing values through `GITHUB_OUTPUT`. | Important |
+| [Docker build-push action](https://github.com/docker/build-push-action) | Documents the action's newline-delimited `build-args` input. | Important |

--- a/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
+++ b/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
@@ -58,11 +58,11 @@ Create one exported version policy for normal workflows and connect the included
 
 None.
 
-- [ ] **Step 1:** Add root `[env]` entries for `JDK_VERSION="25"`, `NODE_VERSION="24"`, and `PNPM_VERSION="11"`.
-- [ ] **Step 2:** Change `[tools]` so Java, Node.js, and pnpm use mise templates referencing the corresponding exported variables; keep unrelated tools unchanged.
-- [ ] **Step 3:** In `backend/gradle/plugins/settings.gradle.kts`, keep the existing single `from(files("../libs.versions.toml"))` import and conditionally call `version("java", value)` only when `providers.environmentVariable("JDK_VERSION")` is present. Let the imported `versions.java` value remain untouched when the variable is absent.
-- [ ] **Step 4:** Leave `backend/gradle/libs.versions.toml`, the generated `Versions.Java` adapter in `backend/gradle/plugins/version-catalog/build.gradle.kts`, and `backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts` unchanged.
-- [ ] **Step 5:** Update the Gradle setup documentation to identify root `mise.toml` as the normal Java version owner and `libs.versions.toml` as the compatibility fallback for Gradle commands invoked without `JDK_VERSION`.
+- [x] **Step 1:** Add root `[env]` entries for `JDK_VERSION="25"`, `NODE_VERSION="24"`, and `PNPM_VERSION="11"`.
+- [x] **Step 2:** Change `[tools]` so Java, Node.js, and pnpm use mise templates referencing the corresponding exported variables; keep unrelated tools unchanged.
+- [x] **Step 3:** In `backend/gradle/plugins/settings.gradle.kts`, keep the existing single `from(files("../libs.versions.toml"))` import and conditionally call `version("java", value)` only when `providers.environmentVariable("JDK_VERSION")` is present. Let the imported `versions.java` value remain untouched when the variable is absent.
+- [x] **Step 4:** Leave `backend/gradle/libs.versions.toml`, the generated `Versions.Java` adapter in `backend/gradle/plugins/version-catalog/build.gradle.kts`, and `backend/gradle/plugins/backend/src/main/kotlin/my.jvm-common.gradle.kts` unchanged.
+- [x] **Step 5:** Update the Gradle setup documentation to identify root `mise.toml` as the normal Java version owner and `libs.versions.toml` as the compatibility fallback for Gradle commands invoked without `JDK_VERSION`.
 
 #### 1.4 Verification
 
@@ -108,13 +108,13 @@ Make every development and production-like image consume the mise-owned values t
 
 Task 1.
 
-- [ ] **Step 1:** Add a global `JDK_VERSION` build argument to the backend Dockerfile and substitute it into the NIK builder and JVM runtime tags. Expose the same value inside `gradle-base` so Gradle toolchain configuration sees it during JVM and native builds.
-- [ ] **Step 2:** Add global `PNPM_VERSION` and `NODE_VERSION` arguments to the frontend Dockerfile. Use them for the pnpm base tag, `pnpm runtime set node`, and the hardened Node.js runtime tag.
-- [ ] **Step 3:** In the shared development Compose file, require `JDK_VERSION` for the API development image, pass it into the API container, and pass required Node.js/pnpm build args into `web-pnpm-base`.
-- [ ] **Step 4:** Require `JDK_VERSION` in the JetBrains API image reference in backend local Compose. Do not add it to that container's environment: IntelliJ replaces this minimal service's entrypoint and mounts built jars, so Gradle does not evaluate the project inside `api-jb`.
-- [ ] **Step 5:** Add required JDK build args to the production-like API build and required Node.js/pnpm build args to its web build.
-- [ ] **Step 6:** Remove `JDK_VERSION` from all three checked-in env templates; do not add Node.js or pnpm versions to them. Retain deployment settings, credentials, ports, runtime targets, and `WEB_PNPM_IMAGE` unchanged.
-- [ ] **Step 7:** Refresh ignored local env files from their templates when needed for verification, preserving any developer-specific credentials or port overrides instead of overwriting them blindly.
+- [x] **Step 1:** Add a global `JDK_VERSION` build argument to the backend Dockerfile and substitute it into the NIK builder and JVM runtime tags. Expose the same value inside `gradle-base` so Gradle toolchain configuration sees it during JVM and native builds.
+- [x] **Step 2:** Add global `PNPM_VERSION` and `NODE_VERSION` arguments to the frontend Dockerfile. Use them for the pnpm base tag, `pnpm runtime set node`, and the hardened Node.js runtime tag.
+- [x] **Step 3:** In the shared development Compose file, require `JDK_VERSION` for the API development image, pass it into the API container, and pass required Node.js/pnpm build args into `web-pnpm-base`.
+- [x] **Step 4:** Require `JDK_VERSION` in the JetBrains API image reference in backend local Compose. Do not add it to that container's environment: IntelliJ replaces this minimal service's entrypoint and mounts built jars, so Gradle does not evaluate the project inside `api-jb`.
+- [x] **Step 5:** Add required JDK build args to the production-like API build and required Node.js/pnpm build args to its web build.
+- [x] **Step 6:** Remove `JDK_VERSION` from all three checked-in env templates; do not add Node.js or pnpm versions to them. Retain deployment settings, credentials, ports, runtime targets, and `WEB_PNPM_IMAGE` unchanged.
+- [x] **Step 7:** Refresh ignored local env files from their templates when needed for verification, preserving any developer-specific credentials or port overrides instead of overwriting them blindly.
 
 #### 2.4 Verification
 
@@ -158,9 +158,9 @@ Prevent CI from bypassing the version bridge and remove maintenance guidance tha
 
 Task 2.
 
-- [ ] **Step 1:** Add a frontend workflow step that reads `NODE_VERSION` and `PNPM_VERSION` through `mise exec`, validates that both are non-empty, and publishes them as step outputs or `GITHUB_ENV` values.
-- [ ] **Step 2:** Pass those derived values to `docker/build-push-action` using its `build-args` input. Do not place `24` or `11` directly in workflow YAML.
-- [ ] **Step 3:** Update Renovate comments so the disabled Java catalog rule is described as protecting the direct-Gradle fallback, which must be kept aligned manually with root `JDK_VERSION`; remove references to literal BellSoft tags as the synchronization mechanism. Keep major language-runtime upgrades manual unless issue #34 explicitly expands into dependency automation.
+- [x] **Step 1:** Add a frontend workflow step that reads `NODE_VERSION` and `PNPM_VERSION` through `mise exec`, validates that both are non-empty, and publishes them as step outputs or `GITHUB_ENV` values.
+- [x] **Step 2:** Pass those derived values to `docker/build-push-action` using its `build-args` input. Do not place `24` or `11` directly in workflow YAML.
+- [x] **Step 3:** Update Renovate comments so the disabled Java catalog rule is described as protecting the direct-Gradle fallback, which must be kept aligned manually with root `JDK_VERSION`; remove references to literal BellSoft tags as the synchronization mechanism. Keep major language-runtime upgrades manual unless issue #34 explicitly expands into dependency automation.
 
 #### 3.4 Verification
 

--- a/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
+++ b/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
@@ -194,7 +194,7 @@ Tasks 1 through 3.
 - [ ] **Step 1:** Document root `mise.toml` as the normal place to change JDK, Node.js, or pnpm major versions and list the downstream consumers. For a JDK upgrade, also update the intentional `libs.versions.toml` fallback in the same change.
 - [ ] **Step 2:** Explain that mise activation or `mise exec`/mise tasks exports versions to Compose, while standalone `docker build` calls must pass the corresponding build args.
 - [ ] **Step 3:** Document Compose shell-over-env-file precedence so developers understand why local and production env templates no longer own runtime versions.
-- [ ] **Step 4:** Search for stale literal version declarations and comments; enumerate and review every remaining match. Retain literals only in root `mise.toml`, the intentional Gradle catalog fallback, immutable historical design logs, or documentation and verification examples that are not active configuration sources.
+- [x] **Step 4:** Search for stale literal version declarations and comments; enumerate and review every remaining match. Retain literals only in root `mise.toml`, the intentional Gradle catalog fallback, immutable historical design logs, or documentation and verification examples that are not active configuration sources.
 
 #### 4.4 Verification
 

--- a/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
+++ b/design-log/plans/plan-issue-34-version-control-mise-dockerfile-20260711.md
@@ -191,9 +191,9 @@ Make the new ownership model discoverable and verify the repository as a whole.
 
 Tasks 1 through 3.
 
-- [ ] **Step 1:** Document root `mise.toml` as the normal place to change JDK, Node.js, or pnpm major versions and list the downstream consumers. For a JDK upgrade, also update the intentional `libs.versions.toml` fallback in the same change.
-- [ ] **Step 2:** Explain that mise activation or `mise exec`/mise tasks exports versions to Compose, while standalone `docker build` calls must pass the corresponding build args.
-- [ ] **Step 3:** Document Compose shell-over-env-file precedence so developers understand why local and production env templates no longer own runtime versions.
+- [x] **Step 1:** Document root `mise.toml` as the normal place to change JDK, Node.js, or pnpm major versions and list the downstream consumers. For a JDK upgrade, also update the intentional `libs.versions.toml` fallback in the same change.
+- [x] **Step 2:** Explain that mise activation or `mise exec`/mise tasks exports versions to Compose, while standalone `docker build` calls must pass the corresponding build args.
+- [x] **Step 3:** Document Compose shell-over-env-file precedence so developers understand why local and production env templates no longer own runtime versions.
 - [x] **Step 4:** Search for stale literal version declarations and comments; enumerate and review every remaining match. Retain literals only in root `mise.toml`, the intentional Gradle catalog fallback, immutable historical design logs, or documentation and verification examples that are not active configuration sources.
 
 #### 4.4 Verification

--- a/docs/docker-setup-explain.md
+++ b/docs/docker-setup-explain.md
@@ -43,8 +43,6 @@ So, each application service, for example, the `api` service on the backend side
 5. The `entrypoint` will use the build tool command. E.g. `./gradlew --no-daemon` for backend services
 6. The `command` defaults to the launch command. E.g. `:apps:api:bootRun` for the API service to make `./gradlew --no-daemon :apps:api:bootRun`
 
-<!-- TODO: more to add -->
-
 ## Q&A
 
 ### For just running any build tool command, why not have a Dockerfile simply copy the source code

--- a/docs/docker-setup-explain.md
+++ b/docs/docker-setup-explain.md
@@ -31,16 +31,17 @@ However, looking at all 4 scenarios, except the last one, all others can be redu
 1. Running a build tool command, whether it is a Gradle task, a pnpm command, a test command, or a server launch command
 2. Production launch
 
-Production launch is the outlier because it is the only one using the Dockerfile, which produces running artifacts with no knowledge of source code or build tools.
+Production launch is the outlier because the final image built only contains running artifacts with no knowledge of source code or build tools.
 
 So, each application service, for example, the `api` service on the backend side, is designed around being able to run any build tool command. Hence the service is set up as:
 
-1. Mount the source code, instead of using Dockerfile
-   - Including directories that are worth caching. E.g. `~/.gradle` for Gradle, so that we can reuse caches in CI
-2. Since source code is mounted, the image would be a standard public image. E.g. Liberica Hardened JDK image for backend services
-3. Since source code is mounted, the user ID and group ID should match the host
-4. The `entrypoint` will use the build tool command. E.g. `./gradlew --no-daemon` for backend services
-5. The `command` defaults to the launch command. E.g. `:apps:api:bootRun` for the API service to make `./gradlew --no-daemon :apps:api:bootRun`
+1. Mount the source code
+2. Mount directories that are worth caching. E.g. `~/.gradle` for Gradle, so that we can reuse caches in CI
+    - The frontend uses named volumes because pnpm relies on symlinks.
+3. Since source code is mounted, the image would need to be based on standard public image. E.g. Liberica Hardened JDK image for backend services
+4. Since source code is mounted, the user ID and group ID should match the host
+5. The `entrypoint` will use the build tool command. E.g. `./gradlew --no-daemon` for backend services
+6. The `command` defaults to the launch command. E.g. `:apps:api:bootRun` for the API service to make `./gradlew --no-daemon :apps:api:bootRun`
 
 <!-- TODO: more to add -->
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -30,7 +30,7 @@ From the repository root, assuming mise is installed:
    mise install
    ```
 
-   It is highly recommended to configure `mise activate` in your shell profile, so that `mise install` will be run automatically when you enter the repository.
+   It is highly recommended to configure `mise activate` in your shell profile, so that the repository's tools and environment variables are activated automatically when you enter the repository.
 
 ### `mise` tasks
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -7,7 +7,7 @@ Before any development work, make sure to have:
 1. (For Windows) git-bash or MSYS2 bash
    - Make sure `PATH` resolves `bash` to git-bash or MSYS2 bash, not `C:\Windows\System32\bash.exe`. Use `Get-Command bash` in PowerShell to check which executable `bash` resolves to.
    - All mise tasks are written for bash. PowerShell is not supported for running tasks.
-   - You can still use PowerShell to run mise and docker commands.
+   - You can still use PowerShell to run docker commands or mise commands other than mise tasks
 
 ## mise-en-place
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -52,10 +52,14 @@ mise :config-check
 mise :run --rm api :apps:api:test
 ```
 
-### `mise` envrionment variables
+### `mise` environment variables
 
-mise also manage some environment variables.
-So far only some runtime versions (JDK, node, pnpm) are managed by environment variables, to be used in Dockerfile and docker compose
+Root [`mise.toml`](../mise.toml) `[env]` owns environment variables used across the whole monorepo. So far only some runtime versions are set this way.
+
+Those values are exported by shell activation, `mise exec`, and mise tasks.
+To change a major version, update `[env]` in the root `mise.toml`.
+
+Environment variables set by root [`mise.toml`](../mise.toml) have higher priority than `.env` / `.env.example` files.
 
 ## Unified Environment by Docker Compose
 

--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -11,8 +11,8 @@ Before any development work, make sure to have:
 
 ## mise-en-place
 
-`mise` manages the rest of the tools needed for development.
-See [`mise.toml`](../mise.toml) for the complete tool list.
+`mise` manages the rest of the tools needed for development, and also set necessary environment variables.
+See [`mise.toml`](../mise.toml) for more details of the setup.
 
 ### `mise install`
 
@@ -30,7 +30,7 @@ From the repository root, assuming mise is installed:
    mise install
    ```
 
-   If `mise activate` is configured in your shell profile, this step is run automatically when you enter the repository.
+   It is highly recommended to configure `mise activate` in your shell profile, so that `mise install` will be run automatically when you enter the repository.
 
 ### `mise` tasks
 
@@ -51,6 +51,11 @@ cd backend/docker
 mise :config-check
 mise :run --rm api :apps:api:test
 ```
+
+### `mise` envrionment variables
+
+mise also manage some environment variables.
+So far only some runtime versions (JDK, node, pnpm) are managed by environment variables, to be used in Dockerfile and docker compose
 
 ## Unified Environment by Docker Compose
 

--- a/frontend/docker/.env.example
+++ b/frontend/docker/.env.example
@@ -5,8 +5,6 @@ COMPOSE_PROJECT_NAME=nijigen-video-site-frontend
 FRONTEND_HTTP_PORT=5173
 WEB_PNPM_IMAGE=nijigen-video-site-web-pnpm:local
 
-JDK_VERSION=25
-
 POSTGRES_DB=nijigen_video_site
 POSTGRES_USER=nijigen
 POSTGRES_PASSWORD=nijigen

--- a/frontend/docker/Dockerfile
+++ b/frontend/docker/Dockerfile
@@ -1,7 +1,11 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/pnpm/pnpm:latest AS frontend-pnpm-base
-RUN pnpm runtime set node 24 -g
+ARG NODE_VERSION
+ARG PNPM_VERSION
+
+FROM ghcr.io/pnpm/pnpm:${PNPM_VERSION} AS frontend-pnpm-base
+ARG NODE_VERSION
+RUN pnpm runtime set node "${NODE_VERSION}" -g
 RUN pnpm config set store-dir /pnpm/store
 WORKDIR /workspace/frontend
 
@@ -19,7 +23,7 @@ RUN pnpm install --offline --frozen-lockfile
 RUN pnpm --filter web build
 
 # BellSoft's hardened Node.js image on GHCR requires authentication.
-FROM bellsoft/hardened-nodejs:24-glibc AS web-runtime
+FROM bellsoft/hardened-nodejs:${NODE_VERSION}-glibc AS web-runtime
 ENV HOST="0.0.0.0"
 ENV PORT="3000"
 WORKDIR /app

--- a/infra/compose/common-dev-services.yml
+++ b/infra/compose/common-dev-services.yml
@@ -9,12 +9,12 @@ services:
     extends:
       file: common-services.yml
       service: api-compose-base
-    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided}-nik-${JDK_VERSION:?JDK_VERSION must be provided}-glibc
+    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}-nik-${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}-glibc
     working_dir: /workspace/backend
     user: "${HOST_UID:?HOST_UID must be provided}:${HOST_GID:?HOST_GID must be provided}"
     environment:
       GRADLE_USER_HOME: /gradle-home
-      JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided}
+      JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}
       CI: ${CI:-}
     entrypoint:
       - ./gradlew
@@ -32,8 +32,8 @@ services:
       dockerfile: docker/Dockerfile
       target: web-pnpm-base
       args:
-        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided}
-        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided}
+        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided, likely from mise.toml}
+        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided, likely from mise.toml}
     image: ${WEB_PNPM_IMAGE:-nijigen-video-site-web-pnpm:local}
     working_dir: /workspace/frontend
     environment:

--- a/infra/compose/common-dev-services.yml
+++ b/infra/compose/common-dev-services.yml
@@ -9,11 +9,12 @@ services:
     extends:
       file: common-services.yml
       service: api-compose-base
-    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:-25}-nik-${JDK_VERSION:-25}-glibc
+    image: ghcr.io/bell-sw/hardened-liberica-native-image-kit-container:jdk-${JDK_VERSION:?JDK_VERSION must be provided}-nik-${JDK_VERSION:?JDK_VERSION must be provided}-glibc
     working_dir: /workspace/backend
     user: "${HOST_UID:?HOST_UID must be provided}:${HOST_GID:?HOST_GID must be provided}"
     environment:
       GRADLE_USER_HOME: /gradle-home
+      JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided}
       CI: ${CI:-}
     entrypoint:
       - ./gradlew
@@ -30,6 +31,9 @@ services:
       context: ../../frontend
       dockerfile: docker/Dockerfile
       target: web-pnpm-base
+      args:
+        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided}
+        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided}
     image: ${WEB_PNPM_IMAGE:-nijigen-video-site-web-pnpm:local}
     working_dir: /workspace/frontend
     environment:

--- a/infra/compose/compose.prod.yml
+++ b/infra/compose/compose.prod.yml
@@ -11,6 +11,9 @@ services:
       context: ../../frontend
       dockerfile: docker/Dockerfile
       target: ${WEB_PROD_RUNTIME_TARGET:-web-runtime}
+      args:
+        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided}
+        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided}
     restart: unless-stopped
 
   api:
@@ -21,6 +24,8 @@ services:
       context: ../../backend
       dockerfile: docker/Dockerfile
       target: ${API_PROD_RUNTIME_TARGET:-api-native-runtime}
+      args:
+        JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided}
     restart: unless-stopped
 
   postgres:

--- a/infra/compose/compose.prod.yml
+++ b/infra/compose/compose.prod.yml
@@ -12,8 +12,8 @@ services:
       dockerfile: docker/Dockerfile
       target: ${WEB_PROD_RUNTIME_TARGET:-web-runtime}
       args:
-        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided}
-        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided}
+        NODE_VERSION: ${NODE_VERSION:?NODE_VERSION must be provided, likely from mise.toml}
+        PNPM_VERSION: ${PNPM_VERSION:?PNPM_VERSION must be provided, likely from mise.toml}
     restart: unless-stopped
 
   api:
@@ -25,7 +25,7 @@ services:
       dockerfile: docker/Dockerfile
       target: ${API_PROD_RUNTIME_TARGET:-api-native-runtime}
       args:
-        JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided}
+        JDK_VERSION: ${JDK_VERSION:?JDK_VERSION must be provided, likely from mise.toml}
     restart: unless-stopped
 
   postgres:

--- a/infra/compose/prod.env.example
+++ b/infra/compose/prod.env.example
@@ -4,7 +4,6 @@
 
 COMPOSE_PROJECT_NAME=nijigen-video-site
 
-JDK_VERSION=25
 API_PROD_RUNTIME_TARGET=api-native-runtime
 WEB_PROD_RUNTIME_TARGET=web-runtime
 

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,8 @@ config_roots = [
 ]
 
 [env]
+# Centralized major versions of important runtimes consumed by Dockerfiles and Compose files
+# See docs/docker-setup-explain.md for the unified container-based dev/prod/CI environment
 JDK_VERSION = "25"
 NODE_VERSION = "24"
 PNPM_VERSION = "11"

--- a/mise.toml
+++ b/mise.toml
@@ -15,15 +15,20 @@ config_roots = [
   "infra/compose",
 ]
 
+[env]
+JDK_VERSION = "25"
+NODE_VERSION = "24"
+PNPM_VERSION = "11"
+
 [tools]
 # We mostly use floating version unless there is a specific reason to pin the version.
 
 # Backend
-java = "lts" # This is only needed for running Gradle itself. For building, Gradle java toolchain is configured with fixed graalvm version 25 to build native image
+java = "{{ env.JDK_VERSION }}"
 
 # Frontend
-node = "24" # pinned the version since this is really used in development
-pnpm = "latest"
+node = "{{ env.NODE_VERSION }}"
+pnpm = "{{ env.PNPM_VERSION }}"
 
 # Others
 uv = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -18,9 +18,15 @@ config_roots = [
 [env]
 # Centralized major versions of important runtimes consumed by Dockerfiles and Compose files
 # See docs/docker-setup-explain.md for the unified container-based dev/prod/CI environment
-JDK_VERSION = "25"
+JDK_VERSION = "25" # keep aligned with java in backend/gradle/libs.versions.toml
 NODE_VERSION = "24"
 PNPM_VERSION = "11"
+# Downstream consumers include:
+# - mise [tools] for the host JDK, Node.js, and pnpm installs
+# - Docker Compose image tags, container environment, and build.args
+# - Dockerfiles via ARG (Compose or CLI --build-arg must supply them)
+# - frontend CI, which reads the values through mise exec and passes Docker build args
+# - the backend Gradle included-plugin build, which overlays JDK_VERSION onto the imported catalog when present
 
 [tools]
 # We mostly use floating version unless there is a specific reason to pin the version.


### PR DESCRIPTION
## Summary

- Make root `mise.toml` the single source of truth for JDK, Node.js, and pnpm major versions
- Bridge those versions into Dockerfiles, Compose, frontend CI, and the Gradle JDK overlay
- Document ownership/export behavior and keep intentional Gradle catalog fallback aligned

Closes #34

## Changes

- Root `[env]` owns `JDK_VERSION`, `NODE_VERSION`, and `PNPM_VERSION`
- Compose/Docker/CI consume those values instead of duplicated pins in env templates
- Backend Gradle catalog keeps `java` as a fallback when `JDK_VERSION` is absent
- Docs and plan updates for the new ownership model

## Test plan

- [ ] `mise install` succeeds with the root runtime majors
- [ ] Supported mise Docker/Compose tasks receive the version env vars
- [ ] Bare Compose without the env vars fails on required interpolation
- [ ] Backend Gradle uses the catalog fallback when `JDK_VERSION` is unset
- [ ] Frontend CI path can pass mise versions as Docker build args

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized Java, Node.js, and pnpm versions for consistent local, container, and CI environments.
  * Development and production builds now use the configured runtime versions and clearly report missing configuration.
  * Frontend images now use explicitly selected Node.js and pnpm versions instead of floating defaults.

* **Documentation**
  * Updated setup guidance for mise, environment variables, Docker services, and application-service configuration.
  * Added a plan documenting runtime version management and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->