### PR TITLE
🧪 test(ci): verify CI Gate ruleset enforcement

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: 'Check local Markdown links'
         run: 'mise //:docs-link-check'
+
+      - name: 'Deliberate CI Gate verification failure'
+        run: 'exit 1'

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -29,6 +29,3 @@ jobs:
 
       - name: 'Check local Markdown links'
         run: 'mise //:docs-link-check'
-
-      - name: 'Deliberate CI Gate verification failure'
-        run: 'exit 1'

--- a/design-log/others/issue-44-ruleset-verification.txt
+++ b/design-log/others/issue-44-ruleset-verification.txt
@@ -1,0 +1,1 @@
+Temporary verification change for the CI Gate ruleset migration.


### PR DESCRIPTION
Temporary verification PR for issue #44. This proves that the migrated ruleset requires only the aggregate CI Gate. It will be closed without merging after red/green enforcement checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a temporary note documenting verification for the CI Gate ruleset migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->