### PR TITLE
♻️ refactor(ci): remove security workflow bridge

### DIFF
--- a/.github/workflows/actions-security-check.yml
+++ b/.github/workflows/actions-security-check.yml
@@ -2,11 +2,6 @@ name: 'Actions Security Check'
 
 on:
   workflow_call:
-  pull_request:
-  push:
-    branches:
-      - 'main'
-  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
Completes issue #44 by removing the temporary standalone Actions security triggers after the ruleset migration to the required aggregate `CI Gate`.

The security workflow remains callable by the top-level CI workflow. Local actionlint, zizmor, full-SHA scan, and documentation link checks pass.