### PR TITLE
Add local agent skills and clarify CI orchestration names

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,7 @@
+# Project Specific Agent Skills
+
+This directory contains agent skills specific to this project.
+
+Following the human-AI common source-of-truth policy in [`docs/README.md`](../docs/README.md), these skills must only delegate to shared documentation. They must not contain information exclusive to AI agents.
+
+Place project information in [`docs/`](../docs/) or the relevant component documentation directory instead.

--- a/.agents/skills/backend-doc/SKILL.md
+++ b/.agents/skills/backend-doc/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: backend-doc
+description: Consult the backend documentation. Use when working inside the backend/ folder.
+---
+
+Read the relevant documentation in [`backend/docs/`](../../../backend/docs/) before working on the backend to ensure your work follows project conventions.

--- a/.agents/skills/frontend-doc/SKILL.md
+++ b/.agents/skills/frontend-doc/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: frontend-doc
+description: Consult the frontend documentation. Use when working inside the frontend/ folder.
+---
+
+Read the relevant documentation in [`frontend/docs/`](../../../frontend/docs/) before working on the frontend to ensure your work follows project conventions.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: 'CI'
+name: 'Quality Checks'
 
 on:
   pull_request:

--- a/.github/workflows/quality-orchestration-check.yml
+++ b/.github/workflows/quality-orchestration-check.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           filters: |
             backend:
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/quality-orchestration-check.yml'
               - '.github/workflows/backend-check.yml'
               - 'backend/**'
               - 'infra/compose/**'
@@ -49,7 +49,7 @@ jobs:
               - 'mise.toml'
               - 'backend/docker/mise.toml'
             frontend:
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/quality-orchestration-check.yml'
               - '.github/workflows/frontend-check.yml'
               - 'frontend/**'
               - 'infra/compose/**'
@@ -99,8 +99,8 @@ jobs:
       DOCKERHUB_USERNAME: '${{ secrets.DOCKERHUB_USERNAME }}'
       DOCKERHUB_TOKEN: '${{ secrets.DOCKERHUB_TOKEN }}'
 
-  ci-gate:
-    name: 'CI Gate'
+  final-gate:
+    name: 'Final Gate'
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     permissions: {}

--- a/nijigen-video-site.code-workspace
+++ b/nijigen-video-site.code-workspace
@@ -5,6 +5,9 @@
       "path": "."
     },
     {
+      "path": ".agents"
+    },
+    {
       "path": ".github"
     },
     {


### PR DESCRIPTION
## Summary

- add backend and frontend skills that delegate to shared documentation
- expose the shared skills to Claude through a relative symlink
- document the human-AI common source-of-truth policy for local skills
- expose `.agents` in the VS Code workspace
- rename the orchestration workflow and its final aggregate gate for clarity
- migrate the required repository check from `CI Gate` to `Final Gate`

## Verification

- `markdownlint-cli2` passes for all added Markdown files
- `actionlint` passes for the renamed orchestration workflow
- `git diff --check` passes
- `.claude/skills` resolves to `.agents/skills`
- the complete `Quality Checks` workflow passes with `Final Gate`
- the active ruleset requires only `Final Gate`

Closes #30