### PR TITLE
♻️ refactor(web): use locale-prefixed Paraglide routing

### DIFF
--- a/design-log/adl/010-locale-prefixed-urls-with-preference-based-entry-redirects.md
+++ b/design-log/adl/010-locale-prefixed-urls-with-preference-based-entry-redirects.md
@@ -1,0 +1,158 @@
+# ADL-010: Locale-Prefixed URLs with Preference-Based Entry Redirects
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Related:** [ADL-009](./009-tanstack-start-bff-with-better-auth.md)
+
+## Context
+
+The web application uses Paraglide JS with TanStack Start. The supported locales are `zh-CN` and `en`, and `zh-CN` remains the `baseLocale`.
+
+Paraglide's default URL pattern leaves the base locale unprefixed. Under that pattern, `/` and every other unprefixed path resolve immediately to `zh-CN`, while English uses `/en/...`. Because the configured strategy evaluates `url` before `cookie` and `preferredLanguage`, a first-time visitor to any unprefixed URI receives Chinese even when the browser prefers English. The client then persists the resolved Chinese locale in the Paraglide locale cookie.
+
+A visitor can enter the site through any user-facing URI, not only `/`. The routing policy therefore needs to work consistently for deep links such as `/videos/123`.
+
+The design needs to satisfy these goals:
+
+- Keep Chinese as the final fallback locale.
+- Respect an explicit locale in a shared URL.
+- Respect a saved locale when an incoming URL does not specify a locale.
+- Use the browser's preferred language for a first visit when no locale cookie exists.
+- Keep SSR output, hydration, shared links, SEO, and potential CDN cache keys deterministic by locale.
+- Avoid duplicating Paraglide compiler options between Vite and test-time code generation.
+
+## Reasoning
+
+### Initial preference-first strategy
+
+The initial strategy was `cookie -> preferredLanguage -> url -> baseLocale`. It supported saved preferences and browser-language negotiation for unprefixed first visits.
+
+Used globally, however, this order allowed a cookie or browser preference to override an explicit localized URL. A user opening an English link could receive Chinese content, which weakened URL shareability, SSR determinism, and locale-based caching.
+
+### URL-first strategy
+
+The strategy was changed to `url -> cookie -> preferredLanguage -> baseLocale` so that a public URL authoritatively identified its locale.
+
+With Paraglide's default URL patterns, the URL strategy also treats every unprefixed URI as the base locale. It therefore always resolves unprefixed entry requests to Chinese and prevents the cookie and preferred-language strategies from running.
+
+### Root-only negotiation
+
+Applying preference-based negotiation only to `/` would solve the homepage case but not deep-link entry. A first-time visitor can arrive at any URI, so root-only handling was rejected.
+
+### CDN and personalized SSR discussion
+
+A shared CDN can safely cache locale-specific HTML only when the locale is represented in the cache key, normally through the URL. Varying the same unprefixed URL by locale cookie or `Accept-Language` risks incorrect cache reuse and cache fragmentation.
+
+Encoding locale in the URL does not make all SSR HTML publicly cacheable. A public video page may still render an authenticated user's name, avatar, permissions, or dehydrated TanStack Query data. Such a response is personalized and must not be placed in a shared full-page cache merely because its locale is deterministic.
+
+This distinction led to separating the language-routing decision from the future authenticated-HTML caching policy.
+
+## Decision
+
+Prefix every supported locale in every localized user-facing page URL:
+
+- Chinese: `/zh-CN/...`
+- English: `/en/...`
+
+This follows the [official TanStack Start Paraglide example](https://github.com/TanStack/router/blob/main/examples/react/start-i18n-paraglide/vite.config.ts), which prefixes both its base and non-base locales while keeping the URL strategy first.
+
+Treat an unprefixed URI as a locale-neutral negotiation entry point rather than a canonical localized page.
+
+Keep the global Paraglide strategy in this order:
+
+```text
+url -> cookie -> preferredLanguage -> baseLocale
+```
+
+Configure `urlPatterns` so that only prefixed paths identify a locale. The resulting request flow is:
+
+```mermaid
+flowchart TD
+    R[Incoming user-facing URI]
+    U{Supported locale prefix?}
+    C{Paraglide locale cookie?}
+    P{Supported preferred language?}
+    B[Use zh-CN base locale]
+    L[Use locale from URL]
+    S[Use saved locale]
+    H[Use preferred locale]
+    D[Redirect to locale-prefixed URI]
+    E[Render explicit localized URI]
+
+    R --> U
+    U -->|Yes| L
+    L --> E
+    U -->|No| C
+    C -->|Yes| S
+    C -->|No| P
+    P -->|Yes| H
+    P -->|No| B
+    S --> D
+    H --> D
+    B --> D
+```
+
+Examples:
+
+| Incoming request | Relevant preference | Result |
+| --- | --- | --- |
+| `/videos/123` | Cookie is `en` | `307 /en/videos/123` |
+| `/videos/123` | No cookie; browser prefers English | `307 /en/videos/123` |
+| `/videos/123` | No supported cookie or browser language | `307 /zh-CN/videos/123` |
+| `/en/videos/123` | Cookie or browser prefers Chinese | Render English URL |
+| `/zh-CN/videos/123` | Cookie or browser prefers English | Render Chinese URL |
+
+Paraglide writes the resolved locale to `PARAGLIDE_LOCALE` when its client runtime initializes. No separate first-visit cookie is required: an absent locale cookie naturally falls through to `preferredLanguage`.
+
+TanStack Router continues to use `deLocalizeUrl` for route matching and `localizeUrl` for emitted URLs. Paraglide middleware performs request-scoped locale resolution and document redirects. Locale changes use Paraglide's URL localization functions so the current path, query string, and hash are preserved.
+
+Store the Paraglide compiler options in one typed module shared by the Vite plugin and programmatic compilation. The Paraglide CLI currently exposes the strategy option but not custom `urlPatterns`, so the test-time compiler entry point calls the compiler API with the same shared options instead of duplicating partial CLI arguments.
+
+## Cache Boundary
+
+This decision makes the language dimension deterministic for prefixed URLs. It does not authorize shared caching of authenticated or otherwise personalized SSR HTML.
+
+Future HTTP cache policy should follow these boundaries:
+
+- Locale-neutral entry redirects should not be treated as canonical cacheable HTML.
+- Anonymous public HTML may be considered for shared caching when its response is identical for all users of that locale.
+- Requests with an authenticated application-session cookie must bypass shared full-page caching when SSR output includes user-specific content.
+- Authenticated workspace HTML and responses containing private dehydrated query data must use an appropriate private or no-store policy.
+- Fingerprinted JavaScript, CSS, fonts, images, thumbnails, and video assets can be cached independently from SSR HTML.
+- Varying a shared HTML cache by the full cookie header is not the preferred design because it creates high-cardinality cache keys and increases the risk of configuration mistakes.
+
+The exact CDN provider, cache rules, cache-control headers, and anonymous-versus-authenticated routing policy remain separate implementation decisions.
+
+## Alternatives Considered
+
+### Keep the base locale unprefixed
+
+This produces shorter Chinese URLs and follows Paraglide's default pattern. It was rejected because an unprefixed URI cannot simultaneously mean "explicit Chinese content" and "language-neutral first-visit entry." Preference-based negotiation would also make the same unprefixed URL produce different outcomes for different visitors.
+
+### Use preference-first strategy globally
+
+The order `cookie -> preferredLanguage -> url -> baseLocale` directly supports first-visit negotiation, but it allows stored or browser preferences to override explicit locale-prefixed links. Route-specific overrides could mitigate this, but they add policy complexity and still leave the unprefixed base-locale ambiguity.
+
+### Add route overrides for every prefixed locale
+
+A global preference-first strategy combined with URL-first overrides for `/en/...`, `/zh-CN/...`, and every future locale can preserve explicit links. This was rejected in favor of URL patterns that naturally make unprefixed URLs fall through while keeping all prefixed URLs URL-authoritative.
+
+### Detect language only on the client
+
+Client-only detection would delay redirects until hydration, cause a visible language or URL change, duplicate server behavior, and weaken SSR and crawler consistency.
+
+### Cache unprefixed HTML by cookie and preferred-language headers
+
+A CDN cache key could include locale cookies and `Accept-Language`, but this increases cache cardinality and operational complexity. It also does not solve authenticated HTML personalization. Locale-prefixed URLs provide a simpler and more observable cache boundary.
+
+## Consequences
+
+- Chinese remains the base and fallback locale but no longer receives shorter unprefixed canonical URLs.
+- Existing and future localized page links include a locale prefix, including the base locale.
+- Unprefixed deep links require a redirect before rendering localized content.
+- Explicit shared links remain stable regardless of the recipient's saved or browser preference.
+- Search-engine canonical URLs, sitemaps, and `hreflang` metadata must use prefixed URLs.
+- Adding a locale requires adding it to the localized URL pattern mappings.
+- The language portion of an HTML cache key can be derived from the URL.
+- Personalized SSR HTML still requires an authenticated cache-bypass or private/no-store policy.
+- Vite builds and test-time Paraglide generation use the same compiler configuration.

--- a/frontend/docs/tech-stack.md
+++ b/frontend/docs/tech-stack.md
@@ -4,7 +4,7 @@
 - **Build & Dependency Management**: [pnpm](https://pnpm.io/motivation) (workspace), [Vite](https://vite.dev/guide/)
 - **Web & Routing**: [TanStack Start](https://tanstack.com/start/latest/docs), [TanStack Router](https://tanstack.com/router/latest/docs)
 - **UI & Styling**: [Tailwind CSS](https://tailwindcss.com/docs), [daisyUI](https://daisyui.com/docs/), [Base UI](https://base-ui.com/react/overview)
-- **State & Data**: [TanStack Query](https://tanstack.com/query/latest/docs), [Zustand](https://zustand.docs.pmnd.rs/)
+- **State & Data**: [TanStack Query](https://tanstack.com/query/latest/docs), [Zustand](https://zustand.docs.pmnd.rs/), [Paraglide JS](https://paraglidejs.com/)
 - **Testing & Linting**: [Vitest](https://vitest.dev/guide/), [Oxlint](https://oxc.rs/docs/guide/usage/linter.html), [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html)
 
 ## Notes

--- a/frontend/docs/ui/ui-baseline.md
+++ b/frontend/docs/ui/ui-baseline.md
@@ -3,3 +3,5 @@
 ## DaisyUI vs Base UI - How to combine
 
 One sentence: Daisy UI provided the theme and CSS, Base UI provides the a11y and interactivity.
+
+- By default, use Base UI, but make use of the theme and CSS from Daisy UI

--- a/frontend/docs/ui/ui-baseline.md
+++ b/frontend/docs/ui/ui-baseline.md
@@ -1,7 +1,7 @@
 # UI Baseline
 
-## DaisyUI vs Base UI - How to combine
+## daisyUI vs Base UI - How to combine
 
-One sentence: Daisy UI provided the theme and CSS, Base UI provides the a11y and interactivity.
+One sentence: daisyUI provides the theme and CSS, Base UI provides the a11y and interactivity.
 
-- By default, use Base UI, but make use of the theme and CSS from Daisy UI
+- By default, use Base UI, but make use of the theme and CSS from daisyUI

--- a/frontend/docs/ui/ui-baseline.md
+++ b/frontend/docs/ui/ui-baseline.md
@@ -1,9 +1,5 @@
 # UI Baseline
 
-## DaisyUI vs Base UI - When to use which
+## DaisyUI vs Base UI - How to combine
 
-Generally DaisyUI for the themeing and CSS, Base UI for anything that needs interactivity.
-
-- Use DaisyUI by default
-- Add Base UI component when DaisyUI is lacking components that fulfill the interactive needs
-- Apply DaisyUI CSS for Base UI components for theme consistency
+One sentence: Daisy UI provided the theme and CSS, Base UI provides the a11y and interactivity.

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -13,7 +13,7 @@
     "lint": "oxlint --deny-warnings .",
     "preview": "vite preview",
     "start": "node .output/server/index.mjs",
-    "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy url cookie preferredLanguage baseLocale",
+    "paraglide": "node ./scripts/compile-paraglide.ts",
     "test": "vitest run",
     "pretest": "pnpm paraglide",
     "typecheck": "tsc --noEmit",

--- a/frontend/web/paraglide.config.ts
+++ b/frontend/web/paraglide.config.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared Paraglide compiler configuration for the web project.
+ * Used by both the Vite plugin and the package-script compiler.
+ */
+import type { CompilerOptions } from '@inlang/paraglide-js'
+
+export const paraglideOptions = {
+  project: './project.inlang',
+  outdir: './src/paraglide',
+  // A localized public URL always identifies one language, which keeps SSR,
+  // shared links, and CDN cache keys deterministic.
+  strategy: ['url', 'cookie', 'preferredLanguage', 'baseLocale'],
+  urlPatterns: [
+    {
+      pattern: ':protocol://:domain(.*)::port?/:path(.*)?',
+      localized: [
+        ['zh-CN', ':protocol://:domain(.*)::port?/zh-CN/:path(.*)?'],
+        ['en', ':protocol://:domain(.*)::port?/en/:path(.*)?'],
+      ],
+    },
+  ],
+} satisfies CompilerOptions

--- a/frontend/web/scripts/compile-paraglide.ts
+++ b/frontend/web/scripts/compile-paraglide.ts
@@ -1,0 +1,5 @@
+import { compile } from '@inlang/paraglide-js'
+
+import { paraglideOptions } from '../paraglide.config.ts'
+
+await compile(paraglideOptions)

--- a/frontend/web/src/i18n.test.ts
+++ b/frontend/web/src/i18n.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   deLocalizeUrl,
+  extractLocaleFromUrl,
   extractLocaleFromRequest,
   localizeUrl,
   localizeHref,
@@ -9,6 +10,7 @@ import {
   overwriteGetLocale,
   baseLocale,
   locales,
+  shouldRedirect,
   strategy,
 } from './paraglide/runtime'
 import * as m from './paraglide/messages'
@@ -26,17 +28,22 @@ describe('i18n URL routing', () => {
     expect(result.pathname).toBe('/')
   })
 
-  it('deLocalizeUrl preserves unprefixed root path (base locale)', () => {
+  it('deLocalizeUrl strips locale prefix from /zh-CN path', () => {
+    const result = deLocalizeUrl('http://localhost:3000/zh-CN')
+    expect(result.pathname).toBe('/')
+  })
+
+  it('deLocalizeUrl preserves unprefixed root as a language negotiation path', () => {
     const result = deLocalizeUrl('http://localhost:3000/')
     expect(result.pathname).toBe('/')
   })
 
-  it('deLocalizeUrl strips locale prefix from /en/some-page', () => {
-    const result = deLocalizeUrl('http://localhost:3000/en/some-page')
+  it('deLocalizeUrl strips locale prefix from localized routes', () => {
+    const result = deLocalizeUrl('http://localhost:3000/zh-CN/some-page')
     expect(result.pathname).toBe('/some-page')
   })
 
-  it('deLocalizeUrl preserves unprefixed /some-page (base locale)', () => {
+  it('deLocalizeUrl preserves unprefixed canonical routes for language negotiation', () => {
     const result = deLocalizeUrl('http://localhost:3000/some-page')
     expect(result.pathname).toBe('/some-page')
   })
@@ -46,14 +53,14 @@ describe('i18n URL routing', () => {
     expect(result.pathname).toBe('/en/')
   })
 
-  it('localizeUrl maps / to / for base locale (zh-CN)', () => {
+  it('localizeUrl maps / to /zh-CN for the base locale', () => {
     const result = localizeUrl('http://localhost:3000/', { locale: 'zh-CN' })
-    expect(result.pathname).toBe('/')
+    expect(result.pathname).toBe('/zh-CN/')
   })
 
-  it('localizeUrl maps /en to / for zh-CN locale', () => {
+  it('localizeUrl switches /en to /zh-CN', () => {
     const result = localizeUrl('http://localhost:3000/en/', { locale: 'zh-CN' })
-    expect(result.pathname).toBe('/')
+    expect(result.pathname).toBe('/zh-CN/')
   })
 
   it('localizeUrl maps /some-page to /en/some-page for en locale', () => {
@@ -68,16 +75,16 @@ describe('i18n URL routing', () => {
     expect(href).toBe('/en/some-page')
   })
 
-  it('localizeHref with base locale preserves unprefixed path', () => {
+  it('localizeHref adds the base locale prefix', () => {
     overwriteGetLocale(() => 'en')
     const href = localizeHref('/en/some-page', { locale: 'zh-CN' })
-    expect(href).toBe('/some-page')
+    expect(href).toBe('/zh-CN/some-page')
   })
 
   it('localizeHref at root switches between locales', () => {
     overwriteGetLocale(() => 'zh-CN')
     expect(localizeHref('/', { locale: 'en' })).toBe('/en/')
-    expect(localizeHref('/', { locale: 'zh-CN' })).toBe('/')
+    expect(localizeHref('/', { locale: 'zh-CN' })).toBe('/zh-CN/')
   })
 
   it('localizeHref preserves query string and hash from a TanStack Router location.href', () => {
@@ -87,7 +94,7 @@ describe('i18n URL routing', () => {
     overwriteGetLocale(() => 'en')
     const locationHref = '/en/some-page?q=search#top'
     const href = localizeHref(locationHref, { locale: 'zh-CN' })
-    expect(href).toBe('/some-page?q=search#top')
+    expect(href).toBe('/zh-CN/some-page?q=search#top')
   })
 })
 
@@ -128,6 +135,12 @@ describe('i18n runtime', () => {
     expect(strategy).toEqual(['url', 'cookie', 'preferredLanguage', 'baseLocale'])
   })
 
+  it('only extracts a URL locale from prefixed routes', () => {
+    expect(extractLocaleFromUrl('http://localhost:3000/some-page')).toBeUndefined()
+    expect(extractLocaleFromUrl('http://localhost:3000/zh-CN/some-page')).toBe('zh-CN')
+    expect(extractLocaleFromUrl('http://localhost:3000/en/some-page')).toBe('en')
+  })
+
   it('uses the URL locale over conflicting cookie and preferred language', () => {
     const request = new Request('http://localhost:3000/en', {
       headers: {
@@ -147,15 +160,43 @@ describe('i18n runtime', () => {
     expect(extractLocaleFromRequest(request)).toBe('en')
   })
 
-  it('uses the unprefixed base-locale URL over fallback preferences', () => {
+  it('uses the saved cookie when the URL is unprefixed', () => {
     const request = new Request('http://localhost:3000/', {
       headers: {
         cookie: 'PARAGLIDE_LOCALE=en',
-        'accept-language': 'en',
+        'accept-language': 'zh-CN',
       },
     })
 
+    expect(extractLocaleFromRequest(request)).toBe('en')
+  })
+
+  it('uses the preferred language when an unprefixed URL has no locale cookie', () => {
+    const request = new Request('http://localhost:3000/some-page', {
+      headers: { 'accept-language': 'en' },
+    })
+
+    expect(extractLocaleFromRequest(request)).toBe('en')
+  })
+
+  it('falls back to the base locale when no request preference is supported', () => {
+    const request = new Request('http://localhost:3000/some-page', {
+      headers: { 'accept-language': 'fr' },
+    })
+
     expect(extractLocaleFromRequest(request)).toBe('zh-CN')
+  })
+
+  it('redirects an unprefixed first visit to the preferred-language URL', async () => {
+    const decision = await shouldRedirect({
+      request: new Request('http://localhost:3000/some-page', {
+        headers: { 'accept-language': 'en' },
+      }),
+    })
+
+    expect(decision.shouldRedirect).toBe(true)
+    expect(decision.locale).toBe('en')
+    expect(decision.redirectUrl?.pathname).toBe('/en/some-page')
   })
 
   it('baseLocale is zh-CN', () => {

--- a/frontend/web/vite.config.ts
+++ b/frontend/web/vite.config.ts
@@ -5,16 +5,12 @@ import tailwindcss from '@tailwindcss/vite'
 import viteReact from '@vitejs/plugin-react'
 import { nitro } from 'nitro/vite'
 
+import { paraglideOptions } from './paraglide.config.ts'
+
 const config = defineConfig({
   resolve: { tsconfigPaths: true },
   plugins: [
-    paraglideVitePlugin({
-      project: './project.inlang',
-      outdir: './src/paraglide',
-      // Keep public URLs authoritative for deterministic SSR, sharing, and CDN caching.
-      // Saved and browser preferences have lower priority if URL routing cannot determine a locale.
-      strategy: ['url', 'cookie', 'preferredLanguage', 'baseLocale'],
-    }),
+    paraglideVitePlugin(paraglideOptions),
     nitro({ rollupConfig: { external: [/^@sentry\//] } }),
     tailwindcss(),
     tanstackStart(),


### PR DESCRIPTION
## Summary

- prefix every supported locale in public URLs while treating unprefixed paths as preference-based entry points
- share typed Paraglide compiler options between Vite and package-script generation
- expand i18n routing and locale-precedence coverage
- record the routing and cache-boundary decision in ADL-010
- clarify the frontend UI and technology documentation

## Verification

- `pnpm --filter web test`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm --filter web format:check`
- `pnpm --filter web build`
- `markdownlint-cli2` on changed Markdown files
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added locale-prefixed URLs for supported languages, including Chinese and English.
  - Unprefixed links now redirect based on saved language preference, browser settings, or the default locale.
  - Added localized route and link handling for deep links while preserving query strings and URL fragments.

- **Documentation**
  - Documented locale routing, redirects, SEO considerations, and implementation guidance.
  - Updated frontend technology and UI guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->